### PR TITLE
problem: goczmq does not support zsock_send

### DIFF
--- a/picture.go
+++ b/picture.go
@@ -6,45 +6,50 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 )
 
+type picturePage struct {
+	intVal  int
+	strVal  string
+	byteVal []byte
+}
 type picture struct {
 	picture string
-	pages   []string
+	pages   []*picturePage
 }
 
 func newPicture(parts ...interface{}) (*picture, error) {
 	numParts := len(parts)
 
 	p := &picture{
-		pages: make([]string, numParts),
+		pages: make([]*picturePage, numParts),
 	}
 
-	picturePages := make([]string, numParts)
+	pictureType := make([]string, numParts)
 
 	for i, val := range parts {
 		switch v := val.(type) {
 		case int:
-			picturePages[i] = "i"
-			p.pages[i] = strconv.Itoa(val.(int))
+			pictureType[i] = "i"
+			p.pages[i] = &picturePage{intVal: val.(int)}
 		case string:
-			picturePages[i] = "s"
-			p.pages[i] = val.(string)
+			pictureType[i] = "s"
+			p.pages[i] = &picturePage{strVal: val.(string)}
 		case []byte:
 			if len(v) > 0 {
-				picturePages[i] = "b"
+				pictureType[i] = "b"
 			} else {
-				picturePages[i] = "n"
+				pictureType[i] = "n"
 			}
-			p.pages[i] = string(val.([]byte))
+			p.pages[i] = &picturePage{byteVal: make([]byte, len(val.([]byte)))}
+			p.pages[i].byteVal = val.([]byte)
 		default:
 			return nil, errors.New(fmt.Sprintf("unsupported type at index %d", i))
 		}
 	}
 
-	p.picture = strings.Join(picturePages, "")
+	p.picture = strings.Join(pictureType, "")
 
 	return p, nil
 }

--- a/picture_test.go
+++ b/picture_test.go
@@ -11,23 +11,23 @@ func TestNewPicture(t *testing.T) {
 	}
 
 	if picture.picture != "sbni" {
-		t.Errorf("picture.picture should be 'sbni', is %s", picture.picture)
+		t.Error("picture.picture should be 'sbni', is %s", picture.picture)
 	}
 
-	if picture.pages[0] != "the" {
-		t.Errorf("picture.pages[0] should be 'the', is %s", picture.pages[0])
+	if picture.pages[0].strVal != "the" {
+		t.Error("picture.pages[0] should be 'the'")
 	}
 
-	if picture.pages[1] != "answer" {
-		t.Errorf("picture.pages[1] should be 'answer', is %s", picture.pages[1])
+	if string(picture.pages[1].byteVal) != "answer" {
+		t.Error("picture.pages[1] should be 'answer'")
 	}
 
-	if picture.pages[2] != "" {
-		t.Errorf("picture.pages[2] should be '', is %s", picture.pages[2])
+	if string(picture.pages[2].byteVal) != "" {
+		t.Error("picture.pages[2] should be ''")
 	}
 
-	if picture.pages[3] != "42" {
-		t.Errorf("picture.pages[3] should be '42', is %s", picture.pages[3])
+	if picture.pages[3].intVal != 42 {
+		t.Error("picture.pages[3] should be '42'")
 	}
 }
 


### PR DESCRIPTION
- created non exported "picture" type to hold multi typed message parts 
- created non exported newPicture function that takes a variadic list of interface{} types and constructs a picture from them
- added test
- added benchmark so that improvements in efficiency of the implementation can be measured.

These will be used to support Zsock.Send, which will wrap zsock_send.
