### PR TITLE
problem: sockopts.xml from czmq was not fully supported

### DIFF
--- a/sockopts.xml
+++ b/sockopts.xml
@@ -72,6 +72,49 @@
         <include name = "3-x options" />
     </version>
     
+    <version major = "3" style = "macro">
+        <!-- Options that are carried forward to 4.0 -->
+        <include name = "3-x options" />
+        
+        <!-- Options that are deprecated in 4.0 -->
+        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER">
+            <restrict type = "ROUTER" />
+        </option>
+        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "delay_attach_on_connect"
+                                           type = "int"    mode = "w"  test = "PUB" />
+    </version>
+
+    <!-- Legacy version 2 -->
+    <version major = "2" style = "macro">
+        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "identity"          type = "string" mode = "rw" test = "SUB" />
+        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" />
+        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
+        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
+        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" />
+        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
+        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
+        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
+        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
+        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
+            <restrict type = "SUB" />
+        </option>
+        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
+            <restrict type = "SUB" />
+        </option>
+        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
+        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" />
+        <option name = "fd"                type = "int"    mode = "r"  test = "SUB" />
+        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" />
+    </version>
+    
     <macro name = "3-x options">
         <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
         <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />

--- a/zsock_option.gsl
+++ b/zsock_option.gsl
@@ -36,6 +36,7 @@ import (
 )
 
 .for version
+.if major = "4"
 .for option
 .if mode = "rw" | mode = "w"
 // Set$(name:pascal) sets the $(name) option for the socket
@@ -72,6 +73,7 @@ func (z *Zsock) $(name:pascal)() $(gotype) {
 .endif
 .endif
 .endfor
+.endif
 .for source
 $(string.trim(.):)
 .endfor


### PR DESCRIPTION
The gsl template for socket options still only supports v4 versions - but now the sockopts.xml file from czmq can be directly used without modification.

Not having to modify the sockopts.xsml from CZMQ is simpler.
