### PR TITLE
Problem: uint64, int64, and uint32 socket options were not supported

### DIFF
--- a/zsock_option.go
+++ b/zsock_option.go
@@ -132,15 +132,6 @@ func (z *Zsock) CurveServer() int {
 	return int(val)
 }
 
-// SetCurvePublickey sets the curve_publickey option for the socket
-
-// CurvePublickey returns the current value of the socket's curve_publickey option
-// SetCurveSecretkey sets the curve_secretkey option for the socket
-
-// CurveSecretkey returns the current value of the socket's curve_secretkey option
-// SetCurveServerkey sets the curve_serverkey option for the socket
-
-// CurveServerkey returns the current value of the socket's curve_serverkey option
 // SetGssapiServer sets the gssapi_server option for the socket
 func (z *Zsock) SetGssapiServer(val int) {
 	C.zsock_set_gssapi_server(unsafe.Pointer(z.zsock_t), C.int(val))
@@ -257,8 +248,16 @@ func (z *Zsock) Rcvhwm() int {
 }
 
 // SetAffinity sets the affinity option for the socket
+func (z *Zsock) SetAffinity(val int) {
+	C.zsock_set_affinity(unsafe.Pointer(z.zsock_t), C.int(val))
+}
 
 // Affinity returns the current value of the socket's affinity option
+func (z *Zsock) Affinity() int {
+	val := C.zsock_affinity(unsafe.Pointer(z.zsock_t))
+	return int(val)
+}
+
 // SetSubscribe sets the subscribe option for the socket
 func (z *Zsock) SetSubscribe(val string) {
 	C.zsock_set_subscribe(unsafe.Pointer(z.zsock_t), C.CString(val))
@@ -369,8 +368,16 @@ func (z *Zsock) Backlog() int {
 }
 
 // SetMaxmsgsize sets the maxmsgsize option for the socket
+func (z *Zsock) SetMaxmsgsize(val int) {
+	C.zsock_set_maxmsgsize(unsafe.Pointer(z.zsock_t), C.int(val))
+}
 
 // Maxmsgsize returns the current value of the socket's maxmsgsize option
+func (z *Zsock) Maxmsgsize() int {
+	val := C.zsock_maxmsgsize(unsafe.Pointer(z.zsock_t))
+	return int(val)
+}
+
 // SetMulticastHops sets the multicast_hops option for the socket
 func (z *Zsock) SetMulticastHops(val int) {
 	C.zsock_set_multicast_hops(unsafe.Pointer(z.zsock_t), C.int(val))
@@ -487,3 +494,4 @@ func (z *Zsock) LastEndpoint() string {
 	val := C.zsock_last_endpoint(unsafe.Pointer(z.zsock_t))
 	return C.GoString(val)
 }
+

--- a/zsock_option.gsl
+++ b/zsock_option.gsl
@@ -39,25 +39,24 @@ import (
 .if major = "4"
 .for option
 .if mode = "rw" | mode = "w"
+.if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 // Set$(name:pascal) sets the $(name) option for the socket
-.if type = "int"
 func (z *Zsock) Set$(name:pascal)(val $(gotype)) {
 	C.zsock_set_$(name)(unsafe.Pointer(z.zsock_t), C.int(val))
 }
 
 .endif
 .if type = "string"
+// Set$(name:pascal) sets the $(name) option for the socket
 func (z *Zsock) Set$(name:pascal)(val $(gotype)) {
 	C.zsock_set_$(name)(unsafe.Pointer(z.zsock_t), C.CString(val))
 }
 
 .endif
-
 .endif
 .if mode = "rw" | mode = "r"
-
+.if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 // $(name:pascal) returns the current value of the socket's $(name) option
-.if type = "int"
 func (z *Zsock) $(name:pascal)() $(gotype) {
 	val := C.zsock_$(name)(unsafe.Pointer(z.zsock_t))
 	return int(val)
@@ -65,6 +64,7 @@ func (z *Zsock) $(name:pascal)() $(gotype) {
 
 .endif
 .if type = "string"
+// $(name:pascal) returns the current value of the socket's $(name) option
 func (z *Zsock) $(name:pascal)() $(gotype) {
 	val := C.zsock_$(name)(unsafe.Pointer(z.zsock_t))
 	return C.GoString(val)

--- a/zsock_option_test.go
+++ b/zsock_option_test.go
@@ -21,293 +21,397 @@ import (
 )
 func TestTos(t *testing.T) {
 	sock := NewZsock(DEALER)
-	expected := 1
-	sock.SetTos(expected)
+	testval := 1
+	sock.SetTos(testval)
 	val := sock.Tos()
-	if val != expected && val != 0 {
-		t.Errorf("Tos returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Tos returned %d, should be %d", val, testval)
 	}
+	sock.Destroy()
+}
+
+func TestRouterHandover(t *testing.T) {
+	sock := NewZsock(ROUTER)
+	testval := 1
+	sock.SetRouterHandover(testval)
+	sock.Destroy()
+}
+
+func TestRouterMandatory(t *testing.T) {
+	sock := NewZsock(ROUTER)
+	testval := 1
+	sock.SetRouterMandatory(testval)
+	sock.Destroy()
+}
+
+func TestProbeRouter(t *testing.T) {
+	sock := NewZsock(DEALER)
+	testval := 1
+	sock.SetProbeRouter(testval)
+	sock.Destroy()
+}
+
+func TestReqRelaxed(t *testing.T) {
+	sock := NewZsock(REQ)
+	testval := 1
+	sock.SetReqRelaxed(testval)
+	sock.Destroy()
+}
+
+func TestReqCorrelate(t *testing.T) {
+	sock := NewZsock(REQ)
+	testval := 1
+	sock.SetReqCorrelate(testval)
+	sock.Destroy()
+}
+
+func TestConflate(t *testing.T) {
+	sock := NewZsock(PUSH)
+	testval := 1
+	sock.SetConflate(testval)
 	sock.Destroy()
 }
 
 func TestZapDomain(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := "test"
-	sock.SetZapDomain(expected)
+	testval := "test"
+	sock.SetZapDomain(testval)
 	val := sock.ZapDomain()
-	if val != expected && val != "" {
-		t.Errorf("ZapDomain returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("ZapDomain returned %s should be %s", val, testval)
 	}
         sock.Destroy()
 }
+
 func TestPlainServer(t *testing.T) {
 	sock := NewZsock(PUB)
-	expected := 1
-	sock.SetPlainServer(expected)
+	testval := 1
+	sock.SetPlainServer(testval)
 	val := sock.PlainServer()
-	if val != expected && val != 0 {
-		t.Errorf("PlainServer returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("PlainServer returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestPlainUsername(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := "test"
-	sock.SetPlainUsername(expected)
+	testval := "test"
+	sock.SetPlainUsername(testval)
 	val := sock.PlainUsername()
-	if val != expected && val != "" {
-		t.Errorf("PlainUsername returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("PlainUsername returned %s should be %s", val, testval)
 	}
         sock.Destroy()
 }
+
 func TestPlainPassword(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := "test"
-	sock.SetPlainPassword(expected)
+	testval := "test"
+	sock.SetPlainPassword(testval)
 	val := sock.PlainPassword()
-	if val != expected && val != "" {
-		t.Errorf("PlainPassword returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("PlainPassword returned %s should be %s", val, testval)
 	}
         sock.Destroy()
 }
+
 func TestIpv6(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetIpv6(expected)
+	testval := 1
+	sock.SetIpv6(testval)
 	val := sock.Ipv6()
-	if val != expected && val != 0 {
-		t.Errorf("Ipv6 returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Ipv6 returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestImmediate(t *testing.T) {
 	sock := NewZsock(DEALER)
-	expected := 1
-	sock.SetImmediate(expected)
+	testval := 1
+	sock.SetImmediate(testval)
 	val := sock.Immediate()
-	if val != expected && val != 0 {
-		t.Errorf("Immediate returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Immediate returned %d, should be %d", val, testval)
 	}
+	sock.Destroy()
+}
+
+func TestRouterRaw(t *testing.T) {
+	sock := NewZsock(ROUTER)
+	testval := 1
+	sock.SetRouterRaw(testval)
 	sock.Destroy()
 }
 
 func TestIpv4only(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetIpv4only(expected)
+	testval := 1
+	sock.SetIpv4only(testval)
 	val := sock.Ipv4only()
-	if val != expected && val != 0 {
-		t.Errorf("Ipv4only returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Ipv4only returned %d, should be %d", val, testval)
 	}
+	sock.Destroy()
+}
+
+func TestDelayAttachOnConnect(t *testing.T) {
+	sock := NewZsock(PUB)
+	testval := 1
+	sock.SetDelayAttachOnConnect(testval)
 	sock.Destroy()
 }
 
 func TestSndhwm(t *testing.T) {
 	sock := NewZsock(PUB)
-	expected := 1
-	sock.SetSndhwm(expected)
+	testval := 1
+	sock.SetSndhwm(testval)
 	val := sock.Sndhwm()
-	if val != expected && val != 0 {
-		t.Errorf("Sndhwm returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Sndhwm returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestRcvhwm(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetRcvhwm(expected)
+	testval := 1
+	sock.SetRcvhwm(testval)
 	val := sock.Rcvhwm()
-	if val != expected && val != 0 {
-		t.Errorf("Rcvhwm returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Rcvhwm returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
+func TestAffinity(t *testing.T) {
+	sock := NewZsock(SUB)
+	testval := 1
+	sock.SetAffinity(testval)
+	val := sock.Affinity()
+	if val != testval && val != 0 {
+		t.Errorf("Affinity returned %d, should be %d", val, testval)
+	}
+	sock.Destroy()
+}
+
+func TestSubscribe(t *testing.T) {
+	sock := NewZsock(SUB)
+	testval := "test"
+	sock.SetSubscribe(testval)
+        sock.Destroy()
+}
+
+func TestUnsubscribe(t *testing.T) {
+	sock := NewZsock(SUB)
+	testval := "test"
+	sock.SetUnsubscribe(testval)
+        sock.Destroy()
+}
+
 func TestIdentity(t *testing.T) {
 	sock := NewZsock(DEALER)
-	expected := "test"
-	sock.SetIdentity(expected)
+	testval := "test"
+	sock.SetIdentity(testval)
 	val := sock.Identity()
-	if val != expected && val != "" {
-		t.Errorf("Identity returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("Identity returned %s should be %s", val, testval)
 	}
         sock.Destroy()
 }
+
 func TestRate(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetRate(expected)
+	testval := 1
+	sock.SetRate(testval)
 	val := sock.Rate()
-	if val != expected && val != 0 {
-		t.Errorf("Rate returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Rate returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestRecoveryIvl(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetRecoveryIvl(expected)
+	testval := 1
+	sock.SetRecoveryIvl(testval)
 	val := sock.RecoveryIvl()
-	if val != expected && val != 0 {
-		t.Errorf("RecoveryIvl returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("RecoveryIvl returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestSndbuf(t *testing.T) {
 	sock := NewZsock(PUB)
-	expected := 1
-	sock.SetSndbuf(expected)
+	testval := 1
+	sock.SetSndbuf(testval)
 	val := sock.Sndbuf()
-	if val != expected && val != 0 {
-		t.Errorf("Sndbuf returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Sndbuf returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestRcvbuf(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetRcvbuf(expected)
+	testval := 1
+	sock.SetRcvbuf(testval)
 	val := sock.Rcvbuf()
-	if val != expected && val != 0 {
-		t.Errorf("Rcvbuf returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Rcvbuf returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestLinger(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetLinger(expected)
+	testval := 1
+	sock.SetLinger(testval)
 	val := sock.Linger()
-	if val != expected && val != 0 {
-		t.Errorf("Linger returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Linger returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestReconnectIvl(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetReconnectIvl(expected)
+	testval := 1
+	sock.SetReconnectIvl(testval)
 	val := sock.ReconnectIvl()
-	if val != expected && val != 0 {
-		t.Errorf("ReconnectIvl returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("ReconnectIvl returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestReconnectIvlMax(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetReconnectIvlMax(expected)
+	testval := 1
+	sock.SetReconnectIvlMax(testval)
 	val := sock.ReconnectIvlMax()
-	if val != expected && val != 0 {
-		t.Errorf("ReconnectIvlMax returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("ReconnectIvlMax returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestBacklog(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetBacklog(expected)
+	testval := 1
+	sock.SetBacklog(testval)
 	val := sock.Backlog()
-	if val != expected && val != 0 {
-		t.Errorf("Backlog returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Backlog returned %d, should be %d", val, testval)
+	}
+	sock.Destroy()
+}
+
+func TestMaxmsgsize(t *testing.T) {
+	sock := NewZsock(SUB)
+	testval := 1
+	sock.SetMaxmsgsize(testval)
+	val := sock.Maxmsgsize()
+	if val != testval && val != 0 {
+		t.Errorf("Maxmsgsize returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestMulticastHops(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetMulticastHops(expected)
+	testval := 1
+	sock.SetMulticastHops(testval)
 	val := sock.MulticastHops()
-	if val != expected && val != 0 {
-		t.Errorf("MulticastHops returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("MulticastHops returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestRcvtimeo(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetRcvtimeo(expected)
+	testval := 1
+	sock.SetRcvtimeo(testval)
 	val := sock.Rcvtimeo()
-	if val != expected && val != 0 {
-		t.Errorf("Rcvtimeo returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Rcvtimeo returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestSndtimeo(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetSndtimeo(expected)
+	testval := 1
+	sock.SetSndtimeo(testval)
 	val := sock.Sndtimeo()
-	if val != expected && val != 0 {
-		t.Errorf("Sndtimeo returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("Sndtimeo returned %d, should be %d", val, testval)
 	}
+	sock.Destroy()
+}
+
+func TestXpubVerbose(t *testing.T) {
+	sock := NewZsock(XPUB)
+	testval := 1
+	sock.SetXpubVerbose(testval)
 	sock.Destroy()
 }
 
 func TestTcpKeepalive(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetTcpKeepalive(expected)
+	testval := 1
+	sock.SetTcpKeepalive(testval)
 	val := sock.TcpKeepalive()
-	if val != expected && val != 0 {
-		t.Errorf("TcpKeepalive returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("TcpKeepalive returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestTcpKeepaliveIdle(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetTcpKeepaliveIdle(expected)
+	testval := 1
+	sock.SetTcpKeepaliveIdle(testval)
 	val := sock.TcpKeepaliveIdle()
-	if val != expected && val != 0 {
-		t.Errorf("TcpKeepaliveIdle returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("TcpKeepaliveIdle returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestTcpKeepaliveCnt(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetTcpKeepaliveCnt(expected)
+	testval := 1
+	sock.SetTcpKeepaliveCnt(testval)
 	val := sock.TcpKeepaliveCnt()
-	if val != expected && val != 0 {
-		t.Errorf("TcpKeepaliveCnt returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("TcpKeepaliveCnt returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestTcpKeepaliveIntvl(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := 1
-	sock.SetTcpKeepaliveIntvl(expected)
+	testval := 1
+	sock.SetTcpKeepaliveIntvl(testval)
 	val := sock.TcpKeepaliveIntvl()
-	if val != expected && val != 0 {
-		t.Errorf("TcpKeepaliveIntvl returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("TcpKeepaliveIntvl returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
 
 func TestTcpAcceptFilter(t *testing.T) {
 	sock := NewZsock(SUB)
-	expected := "127.0.0.1"
-	sock.SetTcpAcceptFilter(expected)
+	testval := "127.0.0.1"
+	sock.SetTcpAcceptFilter(testval)
 	val := sock.TcpAcceptFilter()
-	if val != expected && val != "" {
-		t.Errorf("TcpAcceptFilter returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("TcpAcceptFilter returned %s should be %s", val, testval)
 	}
         sock.Destroy()
 }
+

--- a/zsock_option_test.gsl
+++ b/zsock_option_test.gsl
@@ -27,16 +27,18 @@ import (
 .for version
 .if major = "4"
 .for option where defined(test)
-.if mode = "rw" 
-.if type = "int"
+.if mode = "rw" | mode = "w"
+.if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewZsock($(test:upper))
-	expected := $(test_value?'1':)
-	sock.Set$(name:pascal)(expected)
+	testval := $(test_value?'1':)
+	sock.Set$(name:pascal)(testval)
+.if mode = "rw"
 	val := sock.$(name:pascal)()
-	if val != expected && val != 0 {
-		t.Errorf("$(name:pascal) returned %d, should be %d", val, expected)
+	if val != testval && val != 0 {
+		t.Errorf("$(name:pascal) returned %d, should be %d", val, testval)
 	}
+.endif
 	sock.Destroy()
 }
 
@@ -44,15 +46,35 @@ func Test$(name:pascal)(t *testing.T) {
 .if type = "string"
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewZsock($(test:upper))
-	expected := "$(test_value?'test':)"
-	sock.Set$(name:pascal)(expected)
+	testval := "$(test_value?'test':)"
+	sock.Set$(name:pascal)(testval)
+.if mode = "rw"
 	val := sock.$(name:pascal)()
-	if val != expected && val != "" {
-		t.Errorf("$(name:pascal) returned %s should be %s", val, expected)
+	if val != testval && val != "" {
+		t.Errorf("$(name:pascal) returned %s should be %s", val, testval)
 	}
+.endif
         sock.Destroy()
 }
 
+.endif
+.if mode = "r"
+.if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
+func Test$(name:pascal)(t *testing.T) {
+	sock := NewZsock($(test:upper))
+	_ = sock.$(name:pascal)()
+	sock.Destroy()
+}
+
+.endif
+.if type = "string"
+func Test$(name:pascal)(t *testing.T) {
+	sock := NewZsock($(test:upper))
+	_ = sock.$(name:pascal)()
+	sock.Destroy()
+}
+
+.endif
 .endif
 .endif
 .endfor


### PR DESCRIPTION
- Added support for uint64, int64, and uint32 socket options to gsl templates
- Regenerated source for zsock_option and zsock_option_test
- Cleaned up some template formatting issues.
