### PR TITLE
Problem: we cannot use zproxy

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -1,0 +1,66 @@
+// A Go interface to CZMQ
+package goczmq
+
+/*
+#cgo !windows pkg-config: libczmq
+#cgo windows CFLAGS: -I/usr/local/include
+#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
+#include "czmq.h"
+#include <stdlib.h>
+#include <string.h>
+*/
+import "C"
+
+type Type int
+type Flag int
+
+const (
+	REQ    = Type(C.ZMQ_REQ)
+	REP    = Type(C.ZMQ_REP)
+	DEALER = Type(C.ZMQ_DEALER)
+	ROUTER = Type(C.ZMQ_ROUTER)
+	PUB    = Type(C.ZMQ_PUB)
+	SUB    = Type(C.ZMQ_SUB)
+	XPUB   = Type(C.ZMQ_XPUB)
+	XSUB   = Type(C.ZMQ_XSUB)
+	PUSH   = Type(C.ZMQ_PUSH)
+	PULL   = Type(C.ZMQ_PULL)
+	PAIR   = Type(C.ZMQ_PAIR)
+	STREAM = Type(C.ZMQ_STREAM)
+
+	ZMSG_TAG = 0x003cafe
+	MORE     = Flag(C.ZFRAME_MORE)
+	REUSE    = Flag(C.ZFRAME_REUSE)
+	DONTWAIT = Flag(C.ZFRAME_DONTWAIT)
+)
+
+func getStringType(k Type) string {
+	switch k {
+	case REQ:
+		return "REQ"
+	case REP:
+		return "REP"
+	case DEALER:
+		return "DEALER"
+	case ROUTER:
+		return "ROUTER"
+	case PUB:
+		return "PUB"
+	case SUB:
+		return "SUB"
+	case XPUB:
+		return "XPUB"
+	case XSUB:
+		return "XSUB"
+	case PUSH:
+		return "PUSH"
+	case PULL:
+		return "PULL"
+	case PAIR:
+		return "PAIR"
+	case STREAM:
+		return "STREAM"
+	default:
+		return ""
+	}
+}

--- a/zproxy.go
+++ b/zproxy.go
@@ -8,8 +8,11 @@ package goczmq
 #include "czmq.h"
 
 zactor_t *Zproxy_new () { zactor_t *proxy = zactor_new(zproxy, NULL); return proxy; }
+int send_proxy_command(void *dest, const char *command, const char *socktype, const char *endpoint) { return zstr_sendx(dest, command, socktype, endpoint, NULL); }
 */
 import "C"
+
+import "unsafe"
 
 type Zproxy struct {
 	zactor_t *C.struct__zactor_t
@@ -19,6 +22,20 @@ func NewZproxy() *Zproxy {
 	z := &Zproxy{}
 	z.zactor_t = C.Zproxy_new()
 	return z
+}
+
+func (z *Zproxy) SetFrontend(sockType Type, endpoint string) error {
+	typeString := getStringType(sockType)
+	C.send_proxy_command(unsafe.Pointer(z.zactor_t), C.CString("FRONTEND"), C.CString(typeString), C.CString(endpoint))
+	C.zsock_wait(unsafe.Pointer(z.zactor_t))
+	return nil
+}
+
+func (z *Zproxy) SetBackend(sockType Type, endpoint string) error {
+	typeString := getStringType(sockType)
+	C.send_proxy_command(unsafe.Pointer(z.zactor_t), C.CString("BACKEND"), C.CString(typeString), C.CString(endpoint))
+	C.zsock_wait(unsafe.Pointer(z.zactor_t))
+	return nil
 }
 
 func (z *Zproxy) Destroy() {

--- a/zproxy_test.go
+++ b/zproxy_test.go
@@ -6,5 +6,28 @@ import (
 
 func TestZproxy(t *testing.T) {
 	proxy := NewZproxy()
+	proxy.SetFrontend(PULL, "inproc://proxy_front")
+	proxy.SetBackend(PUSH, "inproc://proxy_back")
+
+	send := NewZsock(PUSH)
+	err := send.Connect("inproc://proxy_front")
+	if err != nil {
+		t.Error(err)
+	}
+
+	recv := NewZsock(PULL)
+	err = recv.Connect("inproc://proxy_back")
+	if err != nil {
+		t.Error(err)
+	}
+
+	send.SendBytes([]byte("hello proxy"), 0)
+	b, err := recv.RecvBytes()
+	if err != nil {
+		t.Error(err)
+	}
+	if string(b) != "hello proxy" {
+		t.Error("message is wrong")
+	}
 	proxy.Destroy()
 }

--- a/zsock.go
+++ b/zsock.go
@@ -20,29 +20,6 @@ import (
 	"unsafe"
 )
 
-type Type int
-type Flag int
-
-const (
-	REQ    = Type(C.ZMQ_REQ)
-	REP    = Type(C.ZMQ_REP)
-	DEALER = Type(C.ZMQ_DEALER)
-	ROUTER = Type(C.ZMQ_ROUTER)
-	PUB    = Type(C.ZMQ_PUB)
-	SUB    = Type(C.ZMQ_SUB)
-	XPUB   = Type(C.ZMQ_XPUB)
-	XSUB   = Type(C.ZMQ_XSUB)
-	PUSH   = Type(C.ZMQ_PUSH)
-	PULL   = Type(C.ZMQ_PULL)
-	PAIR   = Type(C.ZMQ_PAIR)
-	STREAM = Type(C.ZMQ_STREAM)
-
-	ZMSG_TAG = 0x003cafe
-	MORE     = Flag(C.ZFRAME_MORE)
-	REUSE    = Flag(C.ZFRAME_REUSE)
-	DONTWAIT = Flag(C.ZFRAME_DONTWAIT)
-)
-
 type Zsock struct {
 	zsock_t *C.struct__zsock_t
 	file    string


### PR DESCRIPTION
- added NewZproxy.  This returns a Zproxy struct that wraps a C pointer to a zactor_t instance, using a small shim C function
- added Destroy() method for cleaning up a Zproxy
- Added unit test
