### PR TITLE
Problem: Zproxy does not do anything

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -11,6 +11,10 @@ package goczmq
 */
 import "C"
 
+import (
+	"errors"
+)
+
 type Type int
 type Flag int
 
@@ -32,6 +36,10 @@ const (
 	MORE     = Flag(C.ZFRAME_MORE)
 	REUSE    = Flag(C.ZFRAME_REUSE)
 	DONTWAIT = Flag(C.ZFRAME_DONTWAIT)
+)
+
+var (
+	ErrActorCmd = errors.New("error sending actor command")
 )
 
 func getStringType(k Type) string {

--- a/zproxy_test.go
+++ b/zproxy_test.go
@@ -8,6 +8,7 @@ func TestZproxy(t *testing.T) {
 	proxy := NewZproxy()
 	proxy.SetFrontend(PULL, "inproc://proxy_front")
 	proxy.SetBackend(PUSH, "inproc://proxy_back")
+	proxy.SetCapture("inproc://proxy_capture")
 
 	send := NewZsock(PUSH)
 	err := send.Connect("inproc://proxy_front")
@@ -21,8 +22,23 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
+	cap := NewZsock(PULL)
+	err = cap.Bind("inproc://proxy_capture")
+	if err != nil {
+		t.Error(err)
+	}
+
 	send.SendBytes([]byte("hello proxy"), 0)
-	b, err := recv.RecvBytes()
+
+	b, err := cap.RecvBytes()
+	if err != nil {
+		t.Error(err)
+	}
+	if string(b) != "hello proxy" {
+		t.Error("message is wrong")
+	}
+
+	b, err = recv.RecvBytes()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
We could create a new Zproxy and destroy it, but that was it.  Added:
- Zproxy.SetFrontend - sends a command to the czmq zproxy to create a new frontend socket
- Zproxy.SetBackend - sends a command to the czmq zproxy to create a new backend socket
- Zproxy.SetCapture - sends a command to the czmq zproxy to create a new capture socket

Note - cgo does not support variadic C functions.  Originally to get around this limitation I wrote a shim C function that wrapped zstr_sendm for sending proxy commands.  To remove the dependency on that shim, I changed the Zproxy commands to use C.zstr_sendm to send the commands as multi part messages.
