### PR TITLE
Problem: unnecessarily expanded surface area of CZMQ API without need.

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -32,6 +32,9 @@ const (
 	PAIR   = Type(C.ZMQ_PAIR)
 	STREAM = Type(C.ZMQ_STREAM)
 
+	POLLIN  = int(C.ZMQ_POLLIN)
+	POLLOUT = int(C.ZMQ_POLLOUT)
+
 	ZMSG_TAG = 0x003cafe
 	MORE     = Flag(C.ZFRAME_MORE)
 	REUSE    = Flag(C.ZFRAME_REUSE)

--- a/zsock.go
+++ b/zsock.go
@@ -248,10 +248,17 @@ func (z *Zsock) Unbind(endpoint string) error {
 	return nil
 }
 
-// Waiting returns true of there is a waiting incoming
+// Pollin returns true if there is a POLLIN
 // event on the socket
-func (z *Zsock) Waiting() bool {
-	return bool(C.zsock_waiting(z.zsock_t))
+func (z *Zsock) Pollin() bool {
+	return z.Events() == POLLIN
+	// return C.zsock_events(unsafe.Pointer(z.zsock_t)) == C.ZMQ_POLLIN
+}
+
+// Pollout returns true if there is a POLLOUT
+// event on the socket
+func (z *Zsock) Pollout() bool {
+	return z.Events() == POLLOUT
 }
 
 // SendMessage is a variadic function that currently accepts ints,

--- a/zsock_test.go
+++ b/zsock_test.go
@@ -376,25 +376,53 @@ func TestSTREAM(t *testing.T) {
 
 }
 
-func TestWaiting(t *testing.T) {
-	push, err := NewPUSH("inproc://waiting")
+func TestPollin(t *testing.T) {
+	push, err := NewPUSH("inproc://pollin")
 	if err != nil {
 		t.Errorf("NewPUSH failed: %s", err)
 	}
 	defer push.Destroy()
 
-	pull, err := NewPULL("inproc://waiting")
+	pull, err := NewPULL("inproc://pollin")
 	if err != nil {
 		t.Errorf("NewPULL failed: %s", err)
 	}
 	defer pull.Destroy()
+
+	if pull.Pollin() {
+		t.Errorf("Pollin returned true should be false")
+	}
 
 	err = push.SendMessage("Hello", "World")
 	if err != nil {
 		t.Errorf("SendMessage failed: %s", err)
 	}
 
-	if !pull.Waiting() {
-		t.Errorf("Waiting returned false should be true")
+	if !pull.Pollin() {
+		t.Errorf("Pollin returned false should be true")
 	}
+}
+
+func TestPollout(t *testing.T) {
+	push := NewZsock(PUSH)
+	_, err := push.Bind("inproc://pollout")
+	if err != nil {
+		t.Errorf("failed binding test socket: %s", err)
+	}
+	defer push.Destroy()
+
+	if push.Pollout() {
+		t.Errorf("Pollout returned true should be false")
+	}
+
+	pull := NewZsock(PULL)
+	err = pull.Connect("inproc://pollout")
+	if err != nil {
+		t.Errorf("failed connecting test socket: %s", err)
+	}
+
+	if !push.Pollout() {
+		t.Errorf("Pollout returned false should be true")
+	}
+
 }


### PR DESCRIPTION
- moved goczmq's Pollin() and Pollout() functions to use zsock_events to check for events.
- this is simpler
- this will allow me to remove two calls from CZMQ that are only used by me.
