### PR TITLE
Problem: proxy_test did not really test pause and resume

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -110,7 +110,6 @@ func TestZproxy(t *testing.T) {
 	}
 
 	// Test pause/resume functionality
-	// FIXME: improve this test once we can receive with a nowait
 	err = proxy.Pause()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
- Added attempt to send message while proxy paused
- Added checks for waiting messages on sink and tap
- Added receives after proxy resumed
