### PR TITLE
Problem: we don't support zcert

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -1,0 +1,61 @@
+package goczmq
+
+/*
+#cgo !windows pkg-config: libczmq
+#cgo windows CFLAGS: -I/usr/local/include
+#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
+#include "czmq.h"
+
+int Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, value);}
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Cert holds a czmq zcert_t
+type Cert struct {
+	zcert_t *C.struct__zcert_t
+}
+
+// NewCert creates a new empty Cert instance
+func NewCert() *Cert {
+	return &Cert{
+		zcert_t: C.zcert_new(),
+	}
+}
+
+// NewCertFrom creates a new Cert from a public and private key
+func NewCertFrom(public []byte, secret []byte) (*Cert, error) {
+	if len(public) != 32 {
+		return nil, fmt.Errorf("invalid public key")
+	}
+
+	if len(secret) != 32 {
+		return nil, fmt.Errorf("invalid private key")
+	}
+
+	return &Cert{
+		zcert_t: C.zcert_new_from(
+			(*C.byte)(unsafe.Pointer(&public[0])),
+			(*C.byte)(unsafe.Pointer(&secret[0]))),
+	}, nil
+}
+
+// SetMeta sets meta data for a Cert
+func (c *Cert) SetMeta(key string, value string) {
+	C.Set_meta(c.zcert_t, C.CString(key), C.CString(value))
+}
+
+// Meta returns a meta data item from a Cert given a key
+func (c *Cert) Meta(key string) string {
+	val := C.zcert_meta(c.zcert_t, C.CString(key))
+	return C.GoString(val)
+}
+
+// Destroy destroys Cert instance
+func (c *Cert) Destroy() {
+	C.zcert_destroy(&c.zcert_t)
+}

--- a/cert_test.go
+++ b/cert_test.go
@@ -1,0 +1,35 @@
+package goczmq
+
+import (
+	"testing"
+)
+
+func TestCert(t *testing.T) {
+	cert := NewCert()
+
+	cert.SetMeta("email", "taotetek@gmail.com")
+	email := cert.Meta("email")
+	if email != "taotetek@gmail.com" {
+		t.Errorf("meta expected 'taotetek@gmail.com' got '%s'", email)
+	}
+
+	cert.SetMeta("name", "Brian Knox")
+	name := cert.Meta("name")
+	if name != "Brian Knox" {
+		t.Errorf("Meta expected 'Brian Knox' got '%s'", name)
+	}
+
+	cert.SetMeta("organization", "SPEE")
+	organization := cert.Meta("organization")
+	if organization != "SPEE" {
+		t.Errorf("Meta expected 'SPEE' got '%s;", organization)
+	}
+
+	cert.SetMeta("version", "1")
+	version := cert.Meta("version")
+	if version != "1" {
+		t.Errorf("Meta expected '1' got '%s'", version)
+	}
+
+	cert.Destroy()
+}


### PR DESCRIPTION
- added start of cert support

Most of this (all?) could be done in pure Go.  For now, I am wrapping the C libraries.  Once unit tests are in place for all tests we wish to support, we can look at what can be moved up from the C layer into pure Go.
