### PR TITLE
Problem: Auth API was inconsistent

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -71,7 +71,7 @@ func (a *Auth) Allow(address string) error {
 	return nil
 }
 
-func (a *Auth) CurveAllow(allowed string) error {
+func (a *Auth) Curve(allowed string) error {
 	rc := C.zstr_sendm(unsafe.Pointer(a.zactor_t), C.CString("CURVE"))
 	if rc == -1 {
 		return ErrActorCmd

--- a/auth_test.go
+++ b/auth_test.go
@@ -241,7 +241,7 @@ func TestAuthCurveAllow(t *testing.T) {
 	client.SetCurveServerkey(serverKey)
 
 	// allow any cert
-	auth.CurveAllow(CURVE_ALLOW_ANY)
+	auth.Curve(CURVE_ALLOW_ANY)
 
 	// bind the server
 	port, err := server.Bind("tcp://127.0.0.1:*")


### PR DESCRIPTION
Other auth API commands were named after the message sent to the actor ("Verbose", "Deny", "Allow") but "Curve" API call was named "CurveAllow"
- changing CurveAllow to Curve
