### PR TITLE
Problem: Channeler can Connect but not Bind

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -20,8 +20,8 @@ func TestChanneler(t *testing.T) {
 	}
 
 	c := NewChanneler(d1, false)
-	c.Connect <- "inproc://channeler-test"
-	c.Send <- [][]byte{[]byte("ready")}
+	c.AttachChan <- "inproc://channeler-test"
+	c.SendChan <- [][]byte{[]byte("ready")}
 
 	m, err := d2.RecvString()
 	if m != "ready" {
@@ -38,7 +38,7 @@ func TestChanneler(t *testing.T) {
 	}
 
 	select {
-	case msg := <-c.Receive:
+	case msg := <-c.RecvChan:
 		if string(msg[0]) != "Test" {
 			t.Error("Message received on receive channel mismatch")
 			return
@@ -49,7 +49,7 @@ func TestChanneler(t *testing.T) {
 	}
 
 	// Send a message through the channeler and verify d2 gets it
-	c.Send <- [][]byte{[]byte("Test")}
+	c.SendChan <- [][]byte{[]byte("Test")}
 	poller, err := NewPoller(d2)
 	if err != nil {
 		t.Errorf("Error while creating poller: %s", err)

--- a/goczmq.go
+++ b/goczmq.go
@@ -15,22 +15,21 @@ import (
 	"errors"
 )
 
-type Type int
 type Flag int
 
 const (
-	REQ    = Type(C.ZMQ_REQ)
-	REP    = Type(C.ZMQ_REP)
-	DEALER = Type(C.ZMQ_DEALER)
-	ROUTER = Type(C.ZMQ_ROUTER)
-	PUB    = Type(C.ZMQ_PUB)
-	SUB    = Type(C.ZMQ_SUB)
-	XPUB   = Type(C.ZMQ_XPUB)
-	XSUB   = Type(C.ZMQ_XSUB)
-	PUSH   = Type(C.ZMQ_PUSH)
-	PULL   = Type(C.ZMQ_PULL)
-	PAIR   = Type(C.ZMQ_PAIR)
-	STREAM = Type(C.ZMQ_STREAM)
+	REQ    = int(C.ZMQ_REQ)
+	REP    = int(C.ZMQ_REP)
+	DEALER = int(C.ZMQ_DEALER)
+	ROUTER = int(C.ZMQ_ROUTER)
+	PUB    = int(C.ZMQ_PUB)
+	SUB    = int(C.ZMQ_SUB)
+	XPUB   = int(C.ZMQ_XPUB)
+	XSUB   = int(C.ZMQ_XSUB)
+	PUSH   = int(C.ZMQ_PUSH)
+	PULL   = int(C.ZMQ_PULL)
+	PAIR   = int(C.ZMQ_PAIR)
+	STREAM = int(C.ZMQ_STREAM)
 
 	POLLIN  = int(C.ZMQ_POLLIN)
 	POLLOUT = int(C.ZMQ_POLLOUT)
@@ -48,7 +47,7 @@ var (
 	ErrSockAttach = errors.New("error attaching zsock")
 )
 
-func getStringType(k Type) string {
+func getStringType(k int) string {
 	switch k {
 	case REQ:
 		return "REQ"

--- a/proxy.go
+++ b/proxy.go
@@ -31,7 +31,7 @@ func NewProxy() *Proxy {
 
 // SetFrontend accepts a socket type and endpoint, and sends a message
 // to the zactor thread telling it to set up a socket bound to the endpoint.
-func (p *Proxy) SetFrontend(sockType Type, endpoint string) error {
+func (p *Proxy) SetFrontend(sockType int, endpoint string) error {
 	typeString := getStringType(sockType)
 
 	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), C.CString("FRONTEND"))
@@ -59,7 +59,7 @@ func (p *Proxy) SetFrontend(sockType Type, endpoint string) error {
 
 // SetBackend accepts a socket type and endpoint, and sends a message
 // to the zactor thread telling it to set up a socket bound to the endpoint.
-func (p *Proxy) SetBackend(sockType Type, endpoint string) error {
+func (p *Proxy) SetBackend(sockType int, endpoint string) error {
 	typeString := getStringType(sockType)
 
 	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), C.CString("BACKEND"))

--- a/sock.go
+++ b/sock.go
@@ -29,7 +29,7 @@ type Sock struct {
 	zsockT *C.struct__zsock_t
 	file   string
 	line   int
-	zType  Type
+	zType  int
 }
 
 func init() {
@@ -41,7 +41,7 @@ func init() {
 // NewSock creates a new socket.  The caller source and
 // line number are passed so CZMQ can report socket leaks
 // intelligently.
-func NewSock(t Type) *Sock {
+func NewSock(t int) *Sock {
 	var s *Sock
 	_, file, line, ok := runtime.Caller(1)
 
@@ -371,7 +371,7 @@ func (s *Sock) RecvString() (string, error) {
 }
 
 // GetType returns the socket's type
-func (s *Sock) GetType() Type {
+func (s *Sock) GetType() int {
 	return s.zType
 }
 


### PR DESCRIPTION
* Changed channeler "connect" channel to attachChan - channeler can now work with both bound and connected sockets.  Syntax of endpoint mirrors goczmq's (@ for attach, > for bind, no prefix for default)

Note: while I was refactoring I noticed channeler used some golang reserved words like "error" for channel names which made the code a little difficult to read - so I reworked the names of a few variables while making changes.

Second Note: Having a custom "Type" for socket types instead of just using ints was providing no value and was potentially confusing, so I changed the socket types to go ints.