### PR TITLE
Problem: goczmq does not use latest go version for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-        - 1.3
+        - 1.4
 before_install:
         - git clone git://github.com/jedisct1/libsodium.git
         - ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install; sudo ldconfig )

--- a/auth_test.go
+++ b/auth_test.go
@@ -257,7 +257,7 @@ func TestAuthCurveAllow(t *testing.T) {
 	}
 	defer poller.Destroy()
 
-	s := poller.Wait(200)
+	s := poller.Wait(2000)
 	if s == nil {
 		t.Error("should be message waiting and there is none")
 	}


### PR DESCRIPTION
Solution: update .travis.yml to use go 1.4
Additional: tweaked timeout period on poller.Wait in auth test to wait a little longer, as was causing a failure in some environments.