### PR TITLE
Problem: Send / Recv API is confusing and some problems solved are only hypothetical

### DIFF
--- a/GODOC.md
+++ b/GODOC.md
@@ -865,8 +865,8 @@ RecoveryIvl returns the current value of the socket's recovery_ivl option
 ```go
 func (s *Sock) RecvFrame() ([]byte, Flag, error)
 ```
-RecvBytes reads a frame from the socket and returns it as a byte array, Returns
-an error if the call fails.
+RecvFrame reads a frame from the socket and returns it as a byte array, along
+with a more flag and and error (if there is an error)
 
 #### func (*Sock) RecvMessage
 
@@ -882,7 +882,7 @@ of byte arrays.
 func (s *Sock) RecvMessageNoWait() ([][]byte, error)
 ```
 RecvMessageNoWait receives a full message from the socket and returns it as an
-array of byte arrays if one is waiting. returns an empty message and an error if
+array of byte arrays if one is waiting. Returns an empty message and an error if
 one is not immediately available
 
 #### func (*Sock) SendFrame
@@ -898,8 +898,8 @@ single message, or SNDMORE if it is a multi-part message
 ```go
 func (s *Sock) SendMessage(parts [][]byte) error
 ```
-SendMessage accepts a variable number of byte arrays and sends them as a
-multi-part message
+SendMessage accepts an array of byte arrays and sends it as a multi-part
+message.
 
 #### func (*Sock) SetAffinity
 

--- a/GODOC.md
+++ b/GODOC.md
@@ -860,10 +860,10 @@ func (s *Sock) RecoveryIvl() int
 ```
 RecoveryIvl returns the current value of the socket's recovery_ivl option
 
-#### func (*Sock) RecvBytes
+#### func (*Sock) RecvFrame
 
 ```go
-func (s *Sock) RecvBytes() ([]byte, Flag, error)
+func (s *Sock) RecvFrame() ([]byte, Flag, error)
 ```
 RecvBytes reads a frame from the socket and returns it as a byte array, Returns
 an error if the call fails.
@@ -885,69 +885,21 @@ RecvMessageNoWait receives a full message from the socket and returns it as an
 array of byte arrays if one is waiting. returns an empty message and an error if
 one is not immediately available
 
-#### func (*Sock) RecvMultiBytes
+#### func (*Sock) SendFrame
 
 ```go
-func (s *Sock) RecvMultiBytes() ([][]byte, error)
+func (s *Sock) SendFrame(data []byte, flags Flag) error
 ```
-
-#### func (*Sock) RecvMultiString
-
-```go
-func (s *Sock) RecvMultiString() ([]string, error)
-```
-
-#### func (*Sock) RecvString
-
-```go
-func (s *Sock) RecvString() (string, error)
-```
-RecvString reads a frame from the socket and returns it as a string, Returns an
-error if the call fails.
-
-#### func (*Sock) SendBytes
-
-```go
-func (s *Sock) SendBytes(data []byte, flags Flag) error
-```
-SendBytes sends a byte array via the socket. For the flags value, use 0 for a
+SendFrame sends a byte array via the socket. For the flags value, use 0 for a
 single message, or SNDMORE if it is a multi-part message
 
 #### func (*Sock) SendMessage
 
 ```go
-func (s *Sock) SendMessage(parts ...interface{}) error
+func (s *Sock) SendMessage(parts [][]byte) error
 ```
-SendMessage is a variadic function that currently accepts ints, strings, and
-bytes, and sends them as an atomic multi frame message over zeromq as a series
-of byte arrays. In the case of numeric data, the resulting byte array is a
-textual representation of the number (e.g., 100 turns to "100"). This may be
-changed to network byte ordered representation in the near future - I have not
-decided yet!
-
-#### func (*Sock) SendMultiBytes
-
-```go
-func (s *Sock) SendMultiBytes(parts ...[]byte) error
-```
-SendMultiBytes accepts a variable number of byte arrays and sends them as a
+SendMessage accepts a variable number of byte arrays and sends them as a
 multi-part message
-
-#### func (*Sock) SendMultiString
-
-```go
-func (s *Sock) SendMultiString(parts ...string) error
-```
-SendMultiString accepts a variable number of strings and sends them as a
-multi-part message
-
-#### func (*Sock) SendString
-
-```go
-func (s *Sock) SendString(data string, flags Flag) error
-```
-SendString sends a string via the socket. For the flags value, use 0 for a
-single message, or SNDMORE if it is a multi-part message
 
 #### func (*Sock) SetAffinity
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -50,7 +50,8 @@ func TestAuthIPAllow(t *testing.T) {
 	}
 
 	// send a hello world message
-	client.SendString("Hello, World", 0)
+	client.SendFrame([]byte("Hello"), 1)
+	client.SendFrame([]byte("World"), 0)
 
 	// create a poller and add the server socket to it
 	poller, err := NewPoller(server)
@@ -66,12 +67,12 @@ func TestAuthIPAllow(t *testing.T) {
 	}
 
 	// receive the message and check the contents
-	msg, err := s.RecvString()
+	msg, err := s.RecvMessage()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if msg != "Hello, World" {
+	if string(msg[0]) != "Hello" || string(msg[1]) != "World" {
 		t.Error("message not sent properly")
 	}
 }
@@ -151,7 +152,8 @@ func TestAuthPlain(t *testing.T) {
 	// connect to the server as the good client, and send a message.
 	// then poll the server to verify the message arrived, and
 	// receive it.
-	goodClient.SendString("Hello, World", 0)
+	goodClient.SendFrame([]byte("Hello"), 1)
+	goodClient.SendFrame([]byte("World"), 0)
 
 	poller, err := NewPoller(server)
 	if err != nil {
@@ -165,12 +167,12 @@ func TestAuthPlain(t *testing.T) {
 		t.Error("poller should have waiting message!")
 	}
 
-	msg, err := s.RecvString()
+	msg, err := s.RecvMessage()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if msg != "Hello, World" {
+	if string(msg[0]) != "Hello" || string(msg[1]) != "World" {
 		t.Error("message not sent properly")
 	}
 
@@ -182,7 +184,8 @@ func TestAuthPlain(t *testing.T) {
 	}
 
 	// try to send a message.  this should succeed.
-	badClient.SendString("Hello, World", 0)
+	badClient.SendFrame([]byte("Hello"), 1)
+	badClient.SendFrame([]byte("World"), 0)
 
 	// poll for a message.  there should be one.
 	s = poller.Wait(200)
@@ -248,7 +251,8 @@ func TestAuthCurveAllow(t *testing.T) {
 	}
 
 	// try to send a message from the good client
-	goodClient.SendString("Hello, World", 0)
+	goodClient.SendFrame([]byte("Hello"), 1)
+	goodClient.SendFrame([]byte("World"), 0)
 
 	// see if we got a message
 	poller, err := NewPoller(server)
@@ -262,17 +266,18 @@ func TestAuthCurveAllow(t *testing.T) {
 		t.Error("should be message waiting and there is none")
 	}
 
-	msg, err := s.RecvString()
+	msg, err := s.RecvMessage()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if msg != "Hello, World" {
+	if string(msg[0]) != "Hello" || string(msg[1]) != "World" {
 		t.Error("message not sent properly")
 	}
 
 	// try to send a message from the bad client
-	badClient.SendString("Hello, Bad World", 0)
+	badClient.SendFrame([]byte("Hello"), 1)
+	badClient.SendFrame([]byte("Bad World"), 0)
 
 	// poll and verify there is no waiting message from
 	// the bad client.
@@ -360,7 +365,7 @@ func TestAuthCurveCertificate(t *testing.T) {
 	}
 
 	// try to send a message from the good client
-	goodClient.SendString("Hello, Good World", 0)
+	goodClient.SendFrame([]byte("Hello, Good World!"), 0)
 
 	// create a poller to poll the server, and verify
 	// the message from the good client was received.
@@ -375,17 +380,17 @@ func TestAuthCurveCertificate(t *testing.T) {
 		t.Error("should be message waiting and there is none")
 	}
 
-	msg, err := s.RecvString()
+	msg, err := s.RecvMessage()
 	if err != nil {
 		t.Error(err)
 	}
 
-	if msg != "Hello, Good World" {
+	if string(msg[0]) != "Hello, Good World!" {
 		t.Error("message not sent properly")
 	}
 
 	// try to send a message from the bad client
-	badClient.SendString("Hello, Bad World", 0)
+	badClient.SendFrame([]byte("Hello, Bad World"), 0)
 
 	// poll and verify there is no waiting message from
 	// the bad client.

--- a/channeler_test.go
+++ b/channeler_test.go
@@ -23,15 +23,15 @@ func TestChanneler(t *testing.T) {
 	c.AttachChan <- "inproc://channeler-test"
 	c.SendChan <- [][]byte{[]byte("ready")}
 
-	m, err := d2.RecvString()
-	if m != "ready" {
+	m, err := d2.RecvMessage()
+	if string(m[0]) != "ready" {
 		t.Errorf("Expected 'ready' but got %s", m)
 		return
 	}
 
 	// The channeler listens on d1, do a send on d2 and verify the receive
 	// channel of the channeler gets it
-	err = d2.SendMessage("Test")
+	err = d2.SendFrame([]byte("Test"), 0)
 	if err != nil {
 		t.Errorf("d2.SendMessage failed: %s", err)
 		return

--- a/cmd/examples/weatherUpdate/wuclient/wuclient.go
+++ b/cmd/examples/weatherUpdate/wuclient/wuclient.go
@@ -9,10 +9,11 @@ package main
 
 import (
 	"fmt"
-	czmq "github.com/zeromq/goczmq"
 	"os"
 	"strconv"
 	"strings"
+
+	czmq "github.com/zeromq/goczmq"
 )
 
 func main() {
@@ -35,12 +36,12 @@ func main() {
 	subSock.Connect(pubEndpoint)
 
 	for i := 0; i < 100; i++ {
-		msg, err := subSock.RecvString()
+		msg, _, err := subSock.RecvFrame()
 		if err != nil {
 			panic(err)
 		}
 
-		weatherData := strings.Split(msg, " ")
+		weatherData := strings.Split(string(msg), " ")
 		temperature, err := strconv.ParseInt(weatherData[1], 10, 64)
 		if err == nil {
 			totalTemperature += int(temperature)

--- a/cmd/examples/weatherUpdate/wuserver/wuserver.go
+++ b/cmd/examples/weatherUpdate/wuserver/wuserver.go
@@ -8,8 +8,9 @@ package main
 
 import (
 	"fmt"
-	czmq "github.com/zeromq/goczmq"
 	"math/rand"
+
+	czmq "github.com/zeromq/goczmq"
 )
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 		relHumidity := rand.Intn(50) + 10
 
 		msg := fmt.Sprintf("%d %d %d", zipcode, temperature, relHumidity)
-		err := pubSock.SendMessage(msg)
+		err := pubSock.SendFrame([]byte(msg), 0)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/multiperf/multiperf.go
+++ b/cmd/multiperf/multiperf.go
@@ -29,7 +29,7 @@ func main() {
 		defer pushSock.Destroy()
 		for i := 0; i < *messageCount; i++ {
 			payload := make([]byte, *messageSize)
-			err = pushSock.SendMessage(payload)
+			err = pushSock.SendMessage([][]byte{payload})
 			if err != nil {
 				panic(err)
 			}

--- a/cmd/perf/perf.go
+++ b/cmd/perf/perf.go
@@ -31,7 +31,7 @@ func main() {
 
 		for i := 0; i < *messageCount; i++ {
 			payload := make([]byte, *messageSize)
-			err = pushSock.SendBytes(payload, 0)
+			err = pushSock.SendFrame(payload, 0)
 			if err != nil {
 				panic(err)
 			}
@@ -40,7 +40,7 @@ func main() {
 
 	startTime := time.Now()
 	for i := 0; i < *messageCount; i++ {
-		msg, _, err := pullSock.RecvBytes()
+		msg, _, err := pullSock.RecvFrame()
 		if err != nil {
 			panic(err)
 		}

--- a/poller_test.go
+++ b/poller_test.go
@@ -56,7 +56,7 @@ func TestPoller(t *testing.T) {
 	}
 	defer pushSock.Destroy()
 
-	err = pushSock.SendString("Hello", 0)
+	err = pushSock.SendFrame([]byte("Hello"), 0)
 	if err != nil {
 		t.Errorf("SendMessage failed: %s", err)
 	}
@@ -66,13 +66,13 @@ func TestPoller(t *testing.T) {
 		t.Errorf("Wait did not return waiting socket")
 	}
 
-	msg, err := s.RecvString()
+	frame, _, err := s.RecvFrame()
 	if err != nil {
 		t.Errorf("RecvMessage failed: %s", err)
 	}
 
-	if msg != "Hello" {
-		t.Errorf("Expected 'Hello', received %s", msg)
+	if string(frame) != "Hello" {
+		t.Errorf("Expected 'Hello', received %s", string(frame))
 	}
 
 	pushSock2, err := NewPUSH("inproc://poller_pull2")
@@ -80,7 +80,7 @@ func TestPoller(t *testing.T) {
 		t.Errorf("NewPUSH failed: %s", err)
 	}
 
-	err = pushSock2.SendString("World", 0)
+	err = pushSock2.SendFrame([]byte("World"), 0)
 	if err != nil {
 		t.Errorf("SendMessage failed: %s", err)
 	}
@@ -90,13 +90,13 @@ func TestPoller(t *testing.T) {
 		t.Errorf("Wait did not return waiting socket")
 	}
 
-	msg, err = s.RecvString()
+	frame, _, err = s.RecvFrame()
 	if err != nil {
 		t.Errorf("RecvMessage failed: %s", err)
 	}
 
-	if msg != "World" {
-		t.Errorf("Expected 'World', received %s", msg)
+	if string(frame) != "World" {
+		t.Errorf("Expected 'World', received %s", string(frame))
 	}
 
 	poller.Remove(pullSock2)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -52,11 +52,11 @@ func TestZproxy(t *testing.T) {
 	defer tap.Destroy()
 
 	// send some messages and check they arrived
-	faucet.SendBytes([]byte("Hello"), 0)
-	faucet.SendBytes([]byte("World"), 0)
+	faucet.SendFrame([]byte("Hello"), 0)
+	faucet.SendFrame([]byte("World"), 0)
 
 	// check the tap
-	b, f, err := tap.RecvBytes()
+	b, f, err := tap.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}
@@ -69,7 +69,7 @@ func TestZproxy(t *testing.T) {
 		t.Errorf("tap expected %s, received %s", "Hello", string(b))
 	}
 
-	b, f, err = tap.RecvBytes()
+	b, f, err = tap.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}
@@ -83,7 +83,7 @@ func TestZproxy(t *testing.T) {
 	}
 
 	// check the sink
-	b, f, err = sink.RecvBytes()
+	b, f, err = sink.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +96,7 @@ func TestZproxy(t *testing.T) {
 		t.Errorf("sink expected %s, received %s", "Hello", string(b))
 	}
 
-	b, f, err = sink.RecvBytes()
+	b, f, err = sink.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}
@@ -115,7 +115,7 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	faucet.SendBytes([]byte("Belated Hello"), 0)
+	faucet.SendFrame([]byte("Belated Hello"), 0)
 
 	if sink.Pollin() {
 		t.Error("Paused proxy should not pass message but did")
@@ -130,7 +130,7 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	b, f, err = sink.RecvBytes()
+	b, f, err = sink.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}
@@ -143,7 +143,7 @@ func TestZproxy(t *testing.T) {
 		t.Errorf("sink expected %s, received %s", "Belated Hello", string(b))
 	}
 
-	b, f, err = tap.RecvBytes()
+	b, f, err = tap.RecvFrame()
 	if err != nil {
 		t.Error(err)
 	}

--- a/sock.go
+++ b/sock.go
@@ -223,7 +223,7 @@ func (s *Sock) Pollout() bool {
 
 // RecvMessageNoWait receives a full message from the socket
 // and returns it as an array of byte arrays if one is waiting.
-// returns an empty message and an error if one is not immediately
+// Returns an empty message and an error if one is not immediately
 // available
 func (s *Sock) RecvMessageNoWait() ([][]byte, error) {
 	var msg [][]byte
@@ -274,8 +274,8 @@ func (s *Sock) SendFrame(data []byte, flags Flag) error {
 	return nil
 }
 
-// SendMessage accepts a variable number of byte arrays
-// and sends them as a multi-part message
+// SendMessage accepts an array of byte arrays and
+// sends it as a multi-part message.
 func (s *Sock) SendMessage(parts [][]byte) error {
 	var f Flag
 	numParts := len(parts)
@@ -294,8 +294,9 @@ func (s *Sock) SendMessage(parts [][]byte) error {
 	return nil
 }
 
-// RecvBytes reads a frame from the socket and returns it
-// as a byte array,  Returns an error if the call fails.
+// RecvFrame reads a frame from the socket and returns it
+// as a byte array, along with a more flag and and error
+// (if there is an error)
 func (s *Sock) RecvFrame() ([]byte, Flag, error) {
 	frame := C.zframe_recv(unsafe.Pointer(s.zsockT))
 	if frame == nil {


### PR DESCRIPTION
Danger, Will Robinson!  Breaking Changes!

* Get rid of various "String" functions that translate from []byte to string, as translation is simple in go. These functions were solving hypothetical problems.  
* "Frame" in the API terms is now considered to be a []byte
* "Message" in the API terms is now considered to be a [][]byte
* Got rid of various different ways of sending and receiving single message parts and multi-part message, reduced to SendFrame, SendMessage, RecvFrame, RecvMessage
* Refactored all tests appropriately