### PR TITLE
Problem: trying to send empty frame causes index error

### DIFF
--- a/sock.go
+++ b/sock.go
@@ -225,8 +225,14 @@ func (s *Sock) Pollout() bool {
 // value, use 0 for a single message, or SNDMORE if it is
 // a multi-part message
 func (s *Sock) SendFrame(data []byte, flags Flag) error {
-	frame := C.zframe_new(unsafe.Pointer(&data[0]), C.size_t(len(data)))
-	rc := C.zframe_send(&frame, unsafe.Pointer(s.zsockT), C.int(flags))
+	var rc C.int
+	if len(data) == 0 {
+		frame := C.zframe_new(unsafe.Pointer(C.CString("")), C.size_t(len(data)))
+		rc = C.zframe_send(&frame, unsafe.Pointer(s.zsockT), C.int(flags))
+	} else {
+		frame := C.zframe_new(unsafe.Pointer(&data[0]), C.size_t(len(data)))
+		rc = C.zframe_send(&frame, unsafe.Pointer(s.zsockT), C.int(flags))
+	}
 	if rc == C.int(-1) {
 		return errors.New("failed")
 	}

--- a/sock.go
+++ b/sock.go
@@ -226,6 +226,7 @@ func (s *Sock) Pollout() bool {
 // a multi-part message
 func (s *Sock) SendFrame(data []byte, flags Flag) error {
 	var rc C.int
+
 	if len(data) == 0 {
 		frame := C.zframe_new(unsafe.Pointer(C.CString("")), C.size_t(len(data)))
 		rc = C.zframe_send(&frame, unsafe.Pointer(s.zsockT), C.int(flags))
@@ -233,9 +234,11 @@ func (s *Sock) SendFrame(data []byte, flags Flag) error {
 		frame := C.zframe_new(unsafe.Pointer(&data[0]), C.size_t(len(data)))
 		rc = C.zframe_send(&frame, unsafe.Pointer(s.zsockT), C.int(flags))
 	}
+
 	if rc == C.int(-1) {
 		return errors.New("failed")
 	}
+
 	return nil
 }
 

--- a/sock_test.go
+++ b/sock_test.go
@@ -28,6 +28,10 @@ func TestSendFrame(t *testing.T) {
 	}
 
 	frame, flag, err := pullSock.RecvFrame()
+	if err != nil {
+		t.Errorf("pullSock.RecvFrame failed: %s", err)
+	}
+
 	if bytes.Compare(frame, []byte("Hello")) != 0 {
 		t.Errorf("expected 'Hello' received '%s'", frame)
 	}
@@ -58,6 +62,39 @@ func TestSendFrame(t *testing.T) {
 	if string(frame) != "World" {
 		t.Errorf("expected 'World' received '%s'", frame)
 	}
+}
+
+func TestSendEmptyFrame(t *testing.T) {
+	pushSock := NewSock(PUSH)
+	defer pushSock.Destroy()
+
+	pullSock := NewSock(PULL)
+	defer pullSock.Destroy()
+
+	_, err := pullSock.Bind("inproc://test-sock")
+	if err != nil {
+		t.Errorf("repSock.Bind failed: %s", err)
+	}
+
+	err = pushSock.Connect("inproc://test-sock")
+	if err != nil {
+		t.Errorf("reqSock.Connect failed: %s", err)
+	}
+
+	empty := make([]byte, 0)
+	err = pushSock.SendFrame(empty, 0)
+	if err != nil {
+		t.Errorf("pushSock.SendFrame failed: %s", err)
+	}
+
+	frame, _, err := pullSock.RecvFrame()
+	if err != nil {
+		t.Errorf("pullSock.RecvFrame failed: %s", err)
+	}
+	if len(frame) != 0 {
+		t.Errorf("frame should be empty but had len %d", len(frame))
+	}
+
 }
 
 func TestSendMessage(t *testing.T) {


### PR DESCRIPTION
Solution: add a length check to the []byte array passed to SendFrame and handle properly.  This lets us send empty frames, which ZMTP supports.