### PR TITLE
Problem: We want to support easily sending buffers and files over ZeroMQ

### DIFF
--- a/GODOC.md
+++ b/GODOC.md
@@ -459,6 +459,40 @@ func (p *Proxy) Verbose() error
 ```
 Verbose sets the proxy to log information to stdout.
 
+#### type ReadChunker
+
+```go
+type ReadChunker struct {
+}
+```
+
+ReadChunker accepts a socket and a chunkSize, and implements the ReadFrom
+interface.
+
+#### func  NewReadChunker
+
+```go
+func NewReadChunker(s *Sock, cs int64) *ReadChunker
+```
+NewReadChunker takes a socket and a chunkSize and returns a new chunker instance
+
+#### func (*ReadChunker) Destroy
+
+```go
+func (c *ReadChunker) Destroy()
+```
+Destroy calls destroy on the underlying socket to clean it up
+
+#### func (*ReadChunker) ReadFrom
+
+```go
+func (c *ReadChunker) ReadFrom(r io.Reader) (int64, error)
+```
+ReadFrom reads from an io.Reader into a []byte of chunkSize. It writes each
+chunk of data as a frame to the socket. Each frame will have the more flag set
+until the last frame. All data from the io.Reader is sent in one atomic multi
+frame message
+
 #### type Sock
 
 ```go
@@ -867,6 +901,15 @@ func (s *Sock) RecvFrame() ([]byte, Flag, error)
 ```
 RecvFrame reads a frame from the socket and returns it as a byte array, along
 with a more flag and and error (if there is an error)
+
+#### func (*Sock) RecvFrameNoWait
+
+```go
+func (s *Sock) RecvFrameNoWait() ([]byte, Flag, error)
+```
+RecvFrameNoWait receives a frame from the socket and returns it as a byte array
+if one is waiting. Returns an empty frame, a 0 more flag and an error if one is
+not immediately available
 
 #### func (*Sock) RecvMessage
 

--- a/readchunker.go
+++ b/readchunker.go
@@ -1,0 +1,55 @@
+package goczmq
+
+import "io"
+
+// ReadChunker accepts a socket and a chunkSize, and implements
+// the ReadFrom interface.
+type ReadChunker struct {
+	sock      *Sock
+	chunkSize int64
+}
+
+// NewReadChunker takes a socket and a chunkSize and returns a new
+// chunker instance
+func NewReadChunker(s *Sock, cs int64) *ReadChunker {
+	return &ReadChunker{
+		sock:      s,
+		chunkSize: cs,
+	}
+}
+
+// ReadFrom reads from an io.Reader into a []byte of chunkSize.
+// It writes each chunk of data as a frame to the socket.
+// Each frame will have the more flag set until the last frame.
+// All data from the io.Reader is sent in one atomic multi
+// frame message
+func (c *ReadChunker) ReadFrom(r io.Reader) (int64, error) {
+	var total int64
+	var n int
+	var err error
+
+	flag := Flag(1)
+
+	p := make([]byte, c.chunkSize)
+
+	for err == nil {
+		n, err = r.Read(p)
+		if err != nil {
+			flag = Flag(0)
+		}
+
+		err := c.sock.SendFrame(p[:n], flag)
+		if err != nil {
+			return total, err
+		}
+
+		total += int64(n)
+	}
+
+	return total, err
+}
+
+// Destroy calls destroy on the underlying socket to clean it up
+func (c *ReadChunker) Destroy() {
+	c.sock.Destroy()
+}

--- a/readchunker_test.go
+++ b/readchunker_test.go
@@ -1,0 +1,97 @@
+package goczmq
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestChunkerEven(t *testing.T) {
+	in := NewSock(PULL)
+	defer in.Destroy()
+
+	_, err := in.Bind("inproc://chunker-test")
+	if err != nil {
+		t.Fatalf("in.Bind: %s", err)
+	}
+
+	out := NewSock(PUSH)
+	err = out.Connect("inproc://chunker-test")
+	if err != nil {
+		t.Fatalf("out.Connect: %s", err)
+	}
+
+	chunker := NewReadChunker(out, 5)
+	defer chunker.Destroy()
+
+	data := []byte("1234567890")
+	buf := bytes.NewBuffer(data)
+
+	n, err := chunker.ReadFrom(buf)
+
+	if err != io.EOF {
+		t.Errorf("expected io.EOF received %s", err)
+	}
+
+	if n != 10 {
+		t.Errorf("expected 10 bytes read got %d", n)
+	}
+
+	msg, err := in.RecvMessage()
+	if err != nil {
+		t.Errorf("in.RecvMessage: %s", err)
+	}
+
+	if string(msg[0]) != "12345" {
+		t.Errorf("first frame should be '12345', is %s", string(msg[0]))
+	}
+
+	if string(msg[1]) != "67890" {
+		t.Errorf("second frame should be '67890', is %s", string(msg[1]))
+	}
+}
+
+func TestChunkerRemainder(t *testing.T) {
+	in := NewSock(PULL)
+	defer in.Destroy()
+
+	_, err := in.Bind("inproc://chunker-test")
+	if err != nil {
+		t.Fatalf("in.Bind: %s", err)
+	}
+
+	out := NewSock(PUSH)
+	err = out.Connect("inproc://chunker-test")
+	if err != nil {
+		t.Fatalf("out.Connect: %s", err)
+	}
+
+	chunker := NewReadChunker(out, 6)
+	defer chunker.Destroy()
+
+	data := []byte("1234567890")
+	buf := bytes.NewBuffer(data)
+
+	n, err := chunker.ReadFrom(buf)
+
+	if err != io.EOF {
+		t.Errorf("expected io.EOF received %s", err)
+	}
+
+	if n != 10 {
+		t.Errorf("expected 10 bytes read got %d", n)
+	}
+
+	msg, err := in.RecvMessage()
+	if err != nil {
+		t.Errorf("in.RecvMessage: %s", err)
+	}
+
+	if string(msg[0]) != "123456" {
+		t.Errorf("first frame should be '12345', is %s", string(msg[0]))
+	}
+
+	if string(msg[1]) != "7890" {
+		t.Errorf("second frame should be '67890', is %s", string(msg[1]))
+	}
+}


### PR DESCRIPTION
Solution: add a "readchunker" that implements the io.ReaderFrom interface 
See: http://golang.org/pkg/io/#ReaderFrom

NewReadChunker accepts a zeromq socket, and a chunk size.  The ReadFrom function then accepts an io.Reader, and reads it chunk size bytes at a time.  The bytes are sent as a multi part message one frame at a time using sock.SendFrame.  This allows for sequential sending of large files and buffers using frames of a configurable size, and works with any io.Reader.

