### PR TITLE
Problem: goczmq no longer compiles due to czmq function rename

### DIFF
--- a/sock.go
+++ b/sock.go
@@ -80,7 +80,7 @@ func NewSock(t int) *Sock {
 		}
 	}
 
-	s.zsockT = C.zsock_new_(C.int(s.zType), C.CString(s.file), C.size_t(s.line))
+	s.zsockT = C.zsock_new_checked(C.int(s.zType), C.CString(s.file), C.size_t(s.line))
 	return s
 }
 
@@ -409,5 +409,5 @@ func (s *Sock) GetType() int {
 
 // Destroy destroys the underlying zsockT.
 func (s *Sock) Destroy() {
-	C.zsock_destroy_(&s.zsockT, C.CString(s.file), C.size_t(s.line))
+	C.zsock_destroy_checked(&s.zsockT, C.CString(s.file), C.size_t(s.line))
 }


### PR DESCRIPTION
Solution: Rename our calls to the renamed methods