### PR TITLE
Problem: #cgo tags are duplicated, static builds are not possible

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 zactor_t *Auth_new () {

--- a/beacon.go
+++ b/beacon.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 zactor_t *Beacon_new () {

--- a/cert.go
+++ b/cert.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 int Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, value);}

--- a/goczmq.go
+++ b/goczmq.go
@@ -2,9 +2,7 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
+#cgo pkg-config: libczmq libzmq libsodium
 #include "czmq.h"
 #include <stdlib.h>
 #include <string.h>

--- a/gossip.go
+++ b/gossip.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 zactor_t *Gossip_new (char *name) {

--- a/poller.go
+++ b/poller.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 zpoller_t *Poller_new(void *reader) {

--- a/proxy.go
+++ b/proxy.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 
 zactor_t *Zproxy_new () {

--- a/sock.go
+++ b/sock.go
@@ -1,9 +1,6 @@
 package goczmq
 
 /*
-#cgo !windows pkg-config: libczmq
-#cgo windows CFLAGS: -I/usr/local/include
-#cgo windows LDFLAGS: -L/usr/local/lib -lczmq
 #include "czmq.h"
 #include <stdlib.h>
 #include <string.h>
@@ -80,7 +77,7 @@ func NewSock(t int) *Sock {
 		}
 	}
 
-	s.zsockT = C.zsock_new_(C.int(s.zType), C.CString(s.file), C.size_t(s.line))
+	s.zsockT = C.zsock_new_checked(C.int(s.zType), C.CString(s.file), C.size_t(s.line))
 	return s
 }
 
@@ -409,5 +406,5 @@ func (s *Sock) GetType() int {
 
 // Destroy destroys the underlying zsockT.
 func (s *Sock) Destroy() {
-	C.zsock_destroy_(&s.zsockT, C.CString(s.file), C.size_t(s.line))
+	C.zsock_destroy_checked(&s.zsockT, C.CString(s.file), C.size_t(s.line))
 }


### PR DESCRIPTION
Solution: 

* remove #cgo tags from all files except goczmq.go
* Accommodate dependencies for static builds in pkg-config
* Remove hardcoded paths and -l flags, we can just trust pkg-config to do the right thing (And it can be configured to point to /usr/local/lib exclusively if necessary) 