### PR TITLE
Problem: README has redundant info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ## Introduction
 A golang interface to [CZMQ](http://czmq.zeromq.org)
 
-This currently requires CZMQ head, and is targetted to be compatible with the upcoming 3.x release of CZMQ.
-
 ## Installation
 
 ```


### PR DESCRIPTION
* Remove redundant info - installation section covers it

By the way - don't know what happened to my git config but I pushed a couple of minor commits to zeromq/goczmq instead of taotetek/goczmq by accident - sorry about that!

