### PR TITLE
Problem: accidently removed zmq4 shout out when cleaning up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,7 @@ func main() {
 ## GoDoc
 [godoc](https://godoc.org/github.com/zeromq/goczmq)
 
+## See Also
+* [Peter Kleiweg's](https://github.com/pebbe) [zmq4](https://github.com/pebbe/zmq4) bindings
 ## License
 This project uses the MPL v2 license, see LICENSE

--- a/README.md
+++ b/README.md
@@ -100,5 +100,6 @@ func main() {
 
 ## See Also
 * [Peter Kleiweg's](https://github.com/pebbe) [zmq4](https://github.com/pebbe/zmq4) bindings
+
 ## License
 This project uses the MPL v2 license, see LICENSE


### PR DESCRIPTION
Solution: add it back :)