### PR TITLE
Problem: We did not follow go naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func main() {
 	payload_size := len(payload)
 	count := 1000000
 	
-	pullSock, err := goczmq.NewPULL("inproc://test")
+	pullSock, err := goczmq.NewPull("inproc://test")
 	if err != nil {
 		panic(err)
 	}
@@ -55,7 +55,7 @@ func main() {
 	defer pullSock.Destroy()
 
 	go func() {
-		pushSock, err := goczmq.NewPUSH("inproc://test")
+		pushSock, err := goczmq.NewPush("inproc://test")
 		if err != nil {
 			panic(err)
 		}

--- a/auth_test.go
+++ b/auth_test.go
@@ -29,7 +29,7 @@ func TestAuthIPAllow(t *testing.T) {
 	}
 
 	// create a pull socket server
-	server := NewSock(PULL)
+	server := NewSock(Pull)
 	server.SetZapDomain("global")
 	defer server.Destroy()
 
@@ -40,7 +40,7 @@ func TestAuthIPAllow(t *testing.T) {
 	}
 
 	// create a push socket client
-	client := NewSock(PUSH)
+	client := NewSock(Push)
 	defer client.Destroy()
 
 	// connect the client to the server socket
@@ -120,7 +120,7 @@ func TestAuthPlain(t *testing.T) {
 	}
 
 	// create a pull socket server and set it to plain authentication
-	server := NewSock(PULL)
+	server := NewSock(Pull)
 	defer server.Destroy()
 	server.SetZapDomain("global")
 	server.SetPlainServer(1)
@@ -132,13 +132,13 @@ func TestAuthPlain(t *testing.T) {
 	}
 
 	// create a push client that will use the correct password
-	goodClient := NewSock(PUSH)
+	goodClient := NewSock(Push)
 	defer goodClient.Destroy()
 	goodClient.SetPlainUsername("admin")
 	goodClient.SetPlainPassword("Password")
 
 	// create a push client that will use a bad password
-	badClient := NewSock(PUSH)
+	badClient := NewSock(Push)
 	defer badClient.Destroy()
 	badClient.SetPlainUsername("admin")
 	badClient.SetPlainPassword("BadPassword")
@@ -206,7 +206,7 @@ func TestAuthCurveAllow(t *testing.T) {
 
 	// create server socket and a server cert pair,
 	// and apply the cert to the server
-	server := NewSock(PULL)
+	server := NewSock(Pull)
 	defer server.Destroy()
 	server.SetZapDomain("global")
 	serverCert := NewCert()
@@ -217,7 +217,7 @@ func TestAuthCurveAllow(t *testing.T) {
 	// create a client + cert, attach
 	// the cert to the client and set the
 	// clients server key
-	goodClient := NewSock(PUSH)
+	goodClient := NewSock(Push)
 	defer goodClient.Destroy()
 	goodClientCert := NewCert()
 	goodClientCert.Apply(goodClient)
@@ -226,11 +226,11 @@ func TestAuthCurveAllow(t *testing.T) {
 	// create a client, and don't assign a
 	// cert or server key. this client should
 	// be rejected.
-	badClient := NewSock(PUSH)
+	badClient := NewSock(Push)
 	defer badClient.Destroy()
 
 	// allow any cert
-	auth.Curve(CURVE_ALLOW_ANY)
+	auth.Curve(CurveAllowAny)
 
 	// bind the server
 	port, err := server.Bind("tcp://127.0.0.1:*")
@@ -308,7 +308,7 @@ func TestAuthCurveCertificate(t *testing.T) {
 	// create a server socket and server cert pair,
 	// get the public key, and apply to the cert
 	// to the server socket.
-	server := NewSock(PULL)
+	server := NewSock(Pull)
 	defer server.Destroy()
 	server.SetZapDomain("global")
 	serverCert := NewCert()
@@ -319,7 +319,7 @@ func TestAuthCurveCertificate(t *testing.T) {
 	// create a client push socket, create a cert
 	// for it and apply it, and add the server
 	// public key to the client.
-	goodClient := NewSock(PUSH)
+	goodClient := NewSock(Push)
 	defer goodClient.Destroy()
 	goodClientCert := NewCert()
 	defer goodClientCert.Destroy()
@@ -332,7 +332,7 @@ func TestAuthCurveCertificate(t *testing.T) {
 
 	// create a client push socket, and a cert for it.
 	// this cert will not be added to the auth list.
-	badClient := NewSock(PUSH)
+	badClient := NewSock(Push)
 	defer badClient.Destroy()
 	badClientCert := NewCert()
 	defer badClientCert.Destroy()
@@ -421,7 +421,7 @@ func ExampleAuth() {
 	defer func() { os.Remove("client_cert") }()
 
 	// create a server, set its auth domain to global
-	server := NewSock(PUSH)
+	server := NewSock(Push)
 	defer server.Destroy()
 	server.SetZapDomain("global")
 
@@ -435,7 +435,7 @@ func ExampleAuth() {
 	// create a client socket, apply the client
 	// certificate to it, and set the server's
 	// public key so it can connect
-	client := NewSock(PULL)
+	client := NewSock(Pull)
 	defer client.Destroy()
 
 	clientCert.Apply(client)

--- a/beacon_test.go
+++ b/beacon_test.go
@@ -32,7 +32,7 @@ func TestBeacon(t *testing.T) {
 
 	err = listener.Subscribe("HI")
 	if err != nil {
-		t.Errorf("SUBSCRIBE error: %s", err)
+		t.Errorf("SubSCRIBE error: %s", err)
 	}
 
 	speaker.Publish("HI", 100)

--- a/channeler.go
+++ b/channeler.go
@@ -61,7 +61,7 @@ func (c *Channeler) Close() {
 }
 
 func (c *Channeler) loopSend(closeChan <-chan struct{}, sendChan <-chan [][]byte, attachChan <-chan string) {
-	push, err := NewPUSH(fmt.Sprintf(">inproc://goczmq-channeler-%d", c.id))
+	push, err := NewPush(fmt.Sprintf(">inproc://goczmq-channeler-%d", c.id))
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +80,7 @@ func (c *Channeler) loopSend(closeChan <-chan struct{}, sendChan <-chan [][]byte
 				if i == numFrames-1 {
 					f = 0
 				} else {
-					f = MORE
+					f = More
 				}
 
 				_ = push.SendFrame(val, f)
@@ -101,7 +101,7 @@ func (c *Channeler) loopMain(sendChan chan<- [][]byte, recvChan chan<- [][]byte,
 		defer close(errChan)
 	}
 
-	pull, err := NewPULL(fmt.Sprintf("@inproc://goczmq-channeler-%d", c.id))
+	pull, err := NewPull(fmt.Sprintf("@inproc://goczmq-channeler-%d", c.id))
 	if err != nil {
 		panic(err)
 	}
@@ -138,7 +138,7 @@ func (c *Channeler) loopMain(sendChan chan<- [][]byte, recvChan chan<- [][]byte,
 			case "attach":
 				var err error
 				switch int(c.sock.Type()) {
-				case PUB, REP, ROUTER, PUSH, XPUB:
+				case Pub, Rep, Router, Push, XPub:
 					err = c.sock.Attach(string(msg[1]), true)
 				default:
 					err = c.sock.Attach(string(msg[1]), false)

--- a/channeler_test.go
+++ b/channeler_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestChanneler(t *testing.T) {
-	d2 := NewSock(PAIR)
+	d2 := NewSock(Pair)
 	_, err := d2.Bind("inproc://channeler-test")
 	if err != nil {
 		t.Errorf("Error creating d2: %s", err)
 		return
 	}
 
-	d1 := NewSock(PAIR)
+	d1 := NewSock(Pair)
 	if err != nil {
 		t.Errorf("Error creating d1: %s", err)
 		return
@@ -77,7 +77,7 @@ func TestChanneler(t *testing.T) {
 }
 
 func ExampleChanneler() {
-	router := NewSock(ROUTER)
+	router := NewSock(Router)
 	routerChan := NewChanneler(router, false)
 	routerChan.AttachChan <- "inproc://channel_example"
 

--- a/cmd/examples/weatherUpdate/wuclient/wuclient.go
+++ b/cmd/examples/weatherUpdate/wuclient/wuclient.go
@@ -25,7 +25,7 @@ func main() {
 		filter = string(os.Args[1])
 	}
 
-	subSock, err := czmq.NewSUB(pubEndpoint, filter)
+	subSock, err := czmq.NewSub(pubEndpoint, filter)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/examples/weatherUpdate/wuserver/wuserver.go
+++ b/cmd/examples/weatherUpdate/wuserver/wuserver.go
@@ -15,7 +15,7 @@ import (
 
 func main() {
 	pubEndpoint := "tcp://127.0.0.1:5556"
-	pubSock, err := czmq.NewPUB(pubEndpoint)
+	pubSock, err := czmq.NewPub(pubEndpoint)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/multiperf/multiperf.go
+++ b/cmd/multiperf/multiperf.go
@@ -13,7 +13,7 @@ func main() {
 	var messageCount = flag.Int("message_count", 0, "number of messages")
 	flag.Parse()
 
-	pullSock, err := czmq.NewPULL("inproc://test")
+	pullSock, err := czmq.NewPull("inproc://test")
 	if err != nil {
 		panic(err)
 	}
@@ -21,7 +21,7 @@ func main() {
 	defer pullSock.Destroy()
 
 	go func() {
-		pushSock, err := czmq.NewPUSH("inproc://test")
+		pushSock, err := czmq.NewPush("inproc://test")
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/perf/perf.go
+++ b/cmd/perf/perf.go
@@ -13,7 +13,7 @@ func main() {
 	var messageCount = flag.Int("message_count", 0, "number of messages")
 	flag.Parse()
 
-	pullSock := czmq.NewSock(czmq.PULL)
+	pullSock := czmq.NewSock(czmq.Pull)
 	defer pullSock.Destroy()
 
 	_, err := pullSock.Bind("inproc://test")
@@ -22,7 +22,7 @@ func main() {
 	}
 
 	go func() {
-		pushSock := czmq.NewSock(czmq.PUSH)
+		pushSock := czmq.NewSock(czmq.Push)
 		defer pushSock.Destroy()
 		err := pushSock.Connect("inproc://test")
 		if err != nil {

--- a/goczmq.go
+++ b/goczmq.go
@@ -18,28 +18,28 @@ import (
 )
 
 const (
-	REQ    = int(C.ZMQ_REQ)
-	REP    = int(C.ZMQ_REP)
-	DEALER = int(C.ZMQ_DEALER)
-	ROUTER = int(C.ZMQ_ROUTER)
-	PUB    = int(C.ZMQ_PUB)
-	SUB    = int(C.ZMQ_SUB)
-	XPUB   = int(C.ZMQ_XPUB)
-	XSUB   = int(C.ZMQ_XSUB)
-	PUSH   = int(C.ZMQ_PUSH)
-	PULL   = int(C.ZMQ_PULL)
-	PAIR   = int(C.ZMQ_PAIR)
-	STREAM = int(C.ZMQ_STREAM)
+	Req    = int(C.ZMQ_REQ)
+	Rep    = int(C.ZMQ_REP)
+	Dealer = int(C.ZMQ_DEALER)
+	Router = int(C.ZMQ_ROUTER)
+	Pub    = int(C.ZMQ_PUB)
+	Sub    = int(C.ZMQ_SUB)
+	XPub   = int(C.ZMQ_XPUB)
+	XSub   = int(C.ZMQ_XSUB)
+	Push   = int(C.ZMQ_PUSH)
+	Pull   = int(C.ZMQ_PULL)
+	Pair   = int(C.ZMQ_PAIR)
+	Stream = int(C.ZMQ_STREAM)
 
-	POLLIN  = int(C.ZMQ_POLLIN)
-	POLLOUT = int(C.ZMQ_POLLOUT)
+	Pollin  = int(C.ZMQ_POLLIN)
+	Pollout = int(C.ZMQ_POLLOUT)
 
-	ZMSG_TAG = 0x003cafe
-	MORE     = int(C.ZFRAME_MORE)
-	REUSE    = int(C.ZFRAME_REUSE)
-	DONTWAIT = int(C.ZFRAME_DONTWAIT)
+	ZmsgTag  = 0x003cafe
+	More     = int(C.ZFRAME_MORE)
+	Reuse    = int(C.ZFRAME_REUSE)
+	DontWait = int(C.ZFRAME_DONTWAIT)
 
-	CURVE_ALLOW_ANY = "*"
+	CurveAllowAny = "*"
 )
 
 var (
@@ -49,29 +49,29 @@ var (
 
 func getStringType(k int) string {
 	switch k {
-	case REQ:
+	case Req:
 		return "REQ"
-	case REP:
+	case Rep:
 		return "REP"
-	case DEALER:
+	case Dealer:
 		return "DEALER"
-	case ROUTER:
+	case Router:
 		return "ROUTER"
-	case PUB:
+	case Pub:
 		return "PUB"
-	case SUB:
+	case Sub:
 		return "SUB"
-	case XPUB:
+	case XPub:
 		return "XPUB"
-	case XSUB:
+	case XSub:
 		return "XSUB"
-	case PUSH:
+	case Push:
 		return "PUSH"
-	case PULL:
+	case Pull:
 		return "PULL"
-	case PAIR:
+	case Pair:
 		return "PAIR"
-	case STREAM:
+	case Stream:
 		return "STREAM"
 	default:
 		return ""

--- a/gossip.go
+++ b/gossip.go
@@ -59,7 +59,7 @@ func (g *Gossip) Connect(endpoint string) error {
 
 // Publish announces a key / value pair
 func (g *Gossip) Publish(key, value string) error {
-	rc := C.zstr_sendm(unsafe.Pointer(g.zactorT), C.CString("PubLISH"))
+	rc := C.zstr_sendm(unsafe.Pointer(g.zactorT), C.CString("PUBLISH"))
 	if rc == -1 {
 		return ErrActorCmd
 	}

--- a/gossip.go
+++ b/gossip.go
@@ -59,7 +59,7 @@ func (g *Gossip) Connect(endpoint string) error {
 
 // Publish announces a key / value pair
 func (g *Gossip) Publish(key, value string) error {
-	rc := C.zstr_sendm(unsafe.Pointer(g.zactorT), C.CString("PUBLISH"))
+	rc := C.zstr_sendm(unsafe.Pointer(g.zactorT), C.CString("PubLISH"))
 	if rc == -1 {
 		return ErrActorCmd
 	}

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -51,17 +51,17 @@ func TestGossip(t *testing.T) {
 
 	err = client1.Publish("client1-00", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client1.Publish("client1-11", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client1.Publish("client1-22", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client1.Connect("inproc://server1")
@@ -83,17 +83,17 @@ func TestGossip(t *testing.T) {
 
 	err = client2.Publish("client2-00", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client2.Publish("client2-11", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client2.Publish("client2-22", "0000")
 	if err != nil {
-		t.Errorf("PUBLISH: %s", err)
+		t.Errorf("PubLISH: %s", err)
 	}
 
 	err = client2.Connect("inproc://server1")

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -51,17 +51,17 @@ func TestGossip(t *testing.T) {
 
 	err = client1.Publish("client1-00", "0000")
 	if err != nil {
-		t.Errorf("PubLISH: %s", err)
+		t.Errorf("PUBLISH: %s", err)
 	}
 
 	err = client1.Publish("client1-11", "0000")
 	if err != nil {
-		t.Errorf("PubLISH: %s", err)
+		t.Errorf("PUBLISH: %s", err)
 	}
 
 	err = client1.Publish("client1-22", "0000")
 	if err != nil {
-		t.Errorf("PubLISH: %s", err)
+		t.Errorf("PUBLISH: %s", err)
 	}
 
 	err = client1.Connect("inproc://server1")

--- a/poller.go
+++ b/poller.go
@@ -73,7 +73,7 @@ func (p *Poller) Remove(reader *Sock) {
 	}
 }
 
-// Wait waits for the timeout period in milliseconds for a POLLIN
+// Wait waits for the timeout period in milliseconds for a Pollin
 // event, and returns the first socket that returns one
 func (p *Poller) Wait(millis int) *Sock {
 	s := C.zpoller_wait(p.zpollerT, C.int(millis))

--- a/poller_test.go
+++ b/poller_test.go
@@ -3,9 +3,9 @@ package goczmq
 import "testing"
 
 func TestPoller(t *testing.T) {
-	pullSock1, err := NewPULL("inproc://poller_pull1")
+	pullSock1, err := NewPull("inproc://poller_pull1")
 	if err != nil {
-		t.Errorf("NewPULL failed: %s", err)
+		t.Errorf("NewPull failed: %s", err)
 	}
 	defer pullSock1.Destroy()
 
@@ -19,9 +19,9 @@ func TestPoller(t *testing.T) {
 		t.Errorf("Expected number of socks to be 1, was %d", len(poller.socks))
 	}
 
-	pullSock2, err := NewPULL("inproc://poller_pull2")
+	pullSock2, err := NewPull("inproc://poller_pull2")
 	if err != nil {
-		t.Errorf("NewPULL failed: %s", err)
+		t.Errorf("NewPull failed: %s", err)
 	}
 	defer pullSock2.Destroy()
 
@@ -48,9 +48,9 @@ func TestPoller(t *testing.T) {
 		t.Error("Expected each passed zsock to be in the poller")
 	}
 
-	pushSock, err := NewPUSH("inproc://poller_pull1")
+	pushSock, err := NewPush("inproc://poller_pull1")
 	if err != nil {
-		t.Errorf("NewPUSH failed: %s", err)
+		t.Errorf("NewPush failed: %s", err)
 	}
 	defer pushSock.Destroy()
 
@@ -73,9 +73,9 @@ func TestPoller(t *testing.T) {
 		t.Errorf("Expected 'Hello', received %s", string(frame))
 	}
 
-	pushSock2, err := NewPUSH("inproc://poller_pull2")
+	pushSock2, err := NewPush("inproc://poller_pull2")
 	if err != nil {
-		t.Errorf("NewPUSH failed: %s", err)
+		t.Errorf("NewPush failed: %s", err)
 	}
 
 	err = pushSock2.SendFrame([]byte("World"), 0)
@@ -104,7 +104,7 @@ func TestPoller(t *testing.T) {
 }
 
 func PollerExample() {
-	sock1, err := NewROUTER("inproc://poller_example_1")
+	sock1, err := NewRouter("inproc://poller_example_1")
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ func PollerExample() {
 		panic(err)
 	}
 
-	sock2, err := NewROUTER("inproc://poller_example_2")
+	sock2, err := NewRouter("inproc://poller_example_2")
 	if err != nil {
 		panic(err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -85,7 +85,7 @@ func (p *Proxy) SetBackend(sockType int, endpoint string) error {
 	return nil
 }
 
-// SetCapture accepts a socket endpoint and sets up a PUSH socket bound
+// SetCapture accepts a socket endpoint and sets up a Push socket bound
 // to that endpoint, that sends a copy of all messages passing through
 // the proxy.
 func (p *Proxy) SetCapture(endpoint string) error {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -14,12 +14,12 @@ func TestZproxy(t *testing.T) {
 		t.Errorf("VERBOSE error: %s", err)
 	}
 
-	err = proxy.SetFrontend(PULL, "inproc://frontend")
+	err = proxy.SetFrontend(Pull, "inproc://frontend")
 	if err != nil {
 		t.Errorf("FRONTEND error: %s", err)
 	}
 
-	err = proxy.SetBackend(PUSH, "inproc://backend")
+	err = proxy.SetBackend(Push, "inproc://backend")
 	if err != nil {
 		t.Errorf("BACKEND error: %s", err)
 	}
@@ -30,21 +30,21 @@ func TestZproxy(t *testing.T) {
 	}
 
 	// connect application sockets to proxy
-	faucet := NewSock(PUSH)
+	faucet := NewSock(Push)
 	err = faucet.Connect("inproc://frontend")
 	if err != nil {
 		t.Error(err)
 	}
 	defer faucet.Destroy()
 
-	sink := NewSock(PULL)
+	sink := NewSock(Pull)
 	err = sink.Connect("inproc://backend")
 	if err != nil {
 		t.Error(err)
 	}
 	defer sink.Destroy()
 
-	tap := NewSock(PULL)
+	tap := NewSock(Pull)
 	_, err = tap.Bind("inproc://capture")
 	if err != nil {
 		t.Error(err)
@@ -61,8 +61,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "Hello" {
@@ -74,8 +74,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "World" {
@@ -88,8 +88,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "Hello" {
@@ -101,8 +101,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "World" {
@@ -135,8 +135,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "Belated Hello" {
@@ -148,8 +148,8 @@ func TestZproxy(t *testing.T) {
 		t.Error(err)
 	}
 
-	if f == MORE {
-		t.Error("MORE set and should not be")
+	if f == More {
+		t.Error("More set and should not be")
 	}
 
 	if string(b) != "Belated Hello" {
@@ -164,13 +164,13 @@ func ProxyExample() {
 	defer proxy.Destroy()
 
 	// set front end address and socket type
-	err := proxy.SetFrontend(PULL, "inproc://frontend")
+	err := proxy.SetFrontend(Pull, "inproc://frontend")
 	if err != nil {
 		panic(err)
 	}
 
 	// set back end address and socket type
-	err = proxy.SetBackend(PUSH, "inproc://backend")
+	err = proxy.SetBackend(Push, "inproc://backend")
 	if err != nil {
 		panic(err)
 	}

--- a/sock.go
+++ b/sock.go
@@ -44,14 +44,14 @@ func init() {
 }
 
 // GetLastClientID returns the id of the last client you received
-// a message from if the underlying socket is a ROUTER or SERVER
+// a message from if the underlying socket is a Router or SERVER
 // socket
 func (s *Sock) GetLastClientID() []byte {
 	return []byte(s.lastClientID)
 }
 
 // SetLastClientID sets the client id that will be used when
-// sending from a ROUTER or SERVER socket
+// sending from a Router or SERVER socket
 func (s *Sock) SetLastClientID(id []byte) {
 	s.lastClientID = string(id)
 }
@@ -135,18 +135,18 @@ func (s *Sock) Attach(endpoints string, serverish bool) error {
 	return nil
 }
 
-// NewPUB creates a PUB socket and calls Attach.
+// NewPub creates a Pub socket and calls Attach.
 // The socket will Bind by default.
-func NewPUB(endpoints string) (*Sock, error) {
-	s := NewSock(PUB)
+func NewPub(endpoints string) (*Sock, error) {
+	s := NewSock(Pub)
 	return s, s.Attach(endpoints, true)
 }
 
-// NewSUB creates a SUB socket and calls Attach.
+// NewSub creates a Sub socket and calls Attach.
 // 'subscribe' is a comma delimited list of topics to subscribe to.
 // The socket will Connect by default.
-func NewSUB(endpoints string, subscribe string) (*Sock, error) {
-	s := NewSock(SUB)
+func NewSub(endpoints string, subscribe string) (*Sock, error) {
+	s := NewSock(Sub)
 	subscriptions := strings.Split(subscribe, ",")
 
 	for _, topic := range subscriptions {
@@ -156,91 +156,91 @@ func NewSUB(endpoints string, subscribe string) (*Sock, error) {
 	return s, s.Attach(endpoints, false)
 }
 
-// NewREP creates a REP socket and calls Attach.
+// NewRep creates a Rep socket and calls Attach.
 // The socket will Bind by default.
-func NewREP(endpoints string) (*Sock, error) {
-	s := NewSock(REP)
+func NewRep(endpoints string) (*Sock, error) {
+	s := NewSock(Rep)
 	return s, s.Attach(endpoints, true)
 }
 
-// NewREQ creates a REQ socket and calls Attach.
+// NewReq creates a Req socket and calls Attach.
 // The socket will Connect by default.
-func NewREQ(endpoints string) (*Sock, error) {
-	s := NewSock(REQ)
+func NewReq(endpoints string) (*Sock, error) {
+	s := NewSock(Req)
 	return s, s.Attach(endpoints, false)
 }
 
-// NewPULL creates a PULL socket and calls Attach.
+// NewPull creates a Pull socket and calls Attach.
 // The socket will Bind by default.
-func NewPULL(endpoints string) (*Sock, error) {
-	s := NewSock(PULL)
+func NewPull(endpoints string) (*Sock, error) {
+	s := NewSock(Pull)
 	return s, s.Attach(endpoints, true)
 }
 
-// NewPUSH creates a PUSH socket and calls Attach.
+// NewPush creates a Push socket and calls Attach.
 // The socket will Connect by default.
-func NewPUSH(endpoints string) (*Sock, error) {
-	s := NewSock(PUSH)
+func NewPush(endpoints string) (*Sock, error) {
+	s := NewSock(Push)
 	return s, s.Attach(endpoints, false)
 }
 
-// NewROUTER creates a ROUTER socket and calls Attach.
+// NewRouter creates a Router socket and calls Attach.
 // The socket will Bind by default.
-func NewROUTER(endpoints string) (*Sock, error) {
-	s := NewSock(ROUTER)
+func NewRouter(endpoints string) (*Sock, error) {
+	s := NewSock(Router)
 	return s, s.Attach(endpoints, true)
 }
 
-// NewDEALER creates a DEALER socket and calls Attach.
+// NewDealer creates a Dealer socket and calls Attach.
 // The socket will Connect by default.
-func NewDEALER(endpoints string) (*Sock, error) {
-	s := NewSock(DEALER)
+func NewDealer(endpoints string) (*Sock, error) {
+	s := NewSock(Dealer)
 	return s, s.Attach(endpoints, false)
 }
 
-// NewXPUB creates an XPUB socket and calls Attach.
+// NewXPub creates an XPub socket and calls Attach.
 // The socket will Bind by default.
-func NewXPUB(endpoints string) (*Sock, error) {
-	s := NewSock(XPUB)
+func NewXPub(endpoints string) (*Sock, error) {
+	s := NewSock(XPub)
 	return s, s.Attach(endpoints, true)
 }
 
-// NewXSUB creates an XSUB socket and calls Attach.
+// NewXSub creates an XSub socket and calls Attach.
 // The socket will Connect by default.
-func NewXSUB(endpoints string) (*Sock, error) {
-	s := NewSock(XSUB)
+func NewXSub(endpoints string) (*Sock, error) {
+	s := NewSock(XSub)
 	return s, s.Attach(endpoints, false)
 }
 
-// NewPAIR creates a PAIR socket and calls Attach.
+// NewPair creates a Pair socket and calls Attach.
 // The socket will Connect by default.
-func NewPAIR(endpoints string) (*Sock, error) {
-	s := NewSock(PAIR)
+func NewPair(endpoints string) (*Sock, error) {
+	s := NewSock(Pair)
 	return s, s.Attach(endpoints, false)
 }
 
-// NewSTREAM creates a STREAM socket and calls Attach.
+// NewStream creates a Stream socket and calls Attach.
 // The socket will Connect by default.
-func NewSTREAM(endpoints string) (*Sock, error) {
-	s := NewSock(STREAM)
+func NewStream(endpoints string) (*Sock, error) {
+	s := NewSock(Stream)
 	return s, s.Attach(endpoints, false)
 }
 
-// Pollin returns true if there is a POLLIN
+// Pollin returns true if there is a Pollin
 // event on the socket
 func (s *Sock) Pollin() bool {
-	return s.Events() == POLLIN
-	// return C.zsock_events(unsafe.Pointer(s.zsockT)) == C.ZMQ_POLLIN
+	return s.Events() == Pollin
+	// return C.zsock_events(unsafe.Pointer(s.zsockT)) == C.ZMQ_Pollin
 }
 
-// Pollout returns true if there is a POLLOUT
+// Pollout returns true if there is a Pollout
 // event on the socket
 func (s *Sock) Pollout() bool {
-	return s.Events() == POLLOUT
+	return s.Events() == Pollout
 }
 
 // SendFrame sends a byte array via the socket.  For the flags
-// value, use 0 for a single message, or SNDMORE if it is
+// value, use 0 for a single message, or SNDMore if it is
 // a multi-part message
 func (s *Sock) SendFrame(data []byte, flags int) error {
 	var rc C.int
@@ -297,7 +297,7 @@ func (s *Sock) SendMessage(parts [][]byte) error {
 		if i == numParts-1 {
 			f = 0
 		} else {
-			f = MORE
+			f = More
 		}
 
 		err := s.SendFrame(val, f)
@@ -319,7 +319,7 @@ func (s *Sock) RecvMessage() ([][]byte, error) {
 			return msg, err
 		}
 		msg = append(msg, frame)
-		if flag != MORE {
+		if flag != More {
 			break
 		}
 	}
@@ -334,14 +334,14 @@ func (s *Sock) Read(p []byte) (int, error) {
 		return total, err
 	}
 
-	if s.GetType() == ROUTER {
+	if s.GetType() == Router {
 		s.lastClientID = string(frame)
 	} else {
 		copy(p[:], frame[:])
 		total += len(frame)
 	}
 
-	for flag == MORE {
+	for flag == More {
 		frame, flag, err = s.RecvFrame()
 		if err != nil {
 			return total, err
@@ -362,8 +362,8 @@ func (s *Sock) Read(p []byte) (int, error) {
 // Write provides an io.Writer interface to a zeromq socket
 func (s *Sock) Write(p []byte) (int, error) {
 	var total int
-	if s.GetType() == ROUTER {
-		err := s.SendFrame(s.GetLastClientID(), MORE)
+	if s.GetType() == Router {
+		err := s.SendFrame(s.GetLastClientID(), More)
 		if err != nil {
 			return total, err
 		}
@@ -392,7 +392,7 @@ func (s *Sock) RecvMessageNoWait() ([][]byte, error) {
 			return msg, err
 		}
 		msg = append(msg, frame)
-		if flag != MORE {
+		if flag != More {
 			break
 		}
 	}

--- a/sock_option.go
+++ b/sock_option.go
@@ -528,3 +528,4 @@ func (s *Sock) LastEndpoint() string {
 	val := C.zsock_last_endpoint(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
 }
+

--- a/sock_option_test.go
+++ b/sock_option_test.go
@@ -1,6 +1,5 @@
 //go:generate gsl sockopts.xml
 package goczmq
-
 /*  =========================================================================
     zsock_option - get/set 0MQ socket options
 
@@ -21,9 +20,8 @@ package goczmq
 import (
 	"testing"
 )
-
 func TestTos(t *testing.T) {
-	sock := NewSock(DEALER)
+	sock := NewSock(Dealer)
 	testval := 1
 	sock.SetTos(testval)
 	val := sock.Tos()
@@ -34,49 +32,49 @@ func TestTos(t *testing.T) {
 }
 
 func TestRouterHandover(t *testing.T) {
-	sock := NewSock(ROUTER)
+	sock := NewSock(Router)
 	testval := 1
 	sock.SetRouterHandover(testval)
 	sock.Destroy()
 }
 
 func TestRouterMandatory(t *testing.T) {
-	sock := NewSock(ROUTER)
+	sock := NewSock(Router)
 	testval := 1
 	sock.SetRouterMandatory(testval)
 	sock.Destroy()
 }
 
 func TestProbeRouter(t *testing.T) {
-	sock := NewSock(DEALER)
+	sock := NewSock(Dealer)
 	testval := 1
 	sock.SetProbeRouter(testval)
 	sock.Destroy()
 }
 
 func TestReqRelaxed(t *testing.T) {
-	sock := NewSock(REQ)
+	sock := NewSock(Req)
 	testval := 1
 	sock.SetReqRelaxed(testval)
 	sock.Destroy()
 }
 
 func TestReqCorrelate(t *testing.T) {
-	sock := NewSock(REQ)
+	sock := NewSock(Req)
 	testval := 1
 	sock.SetReqCorrelate(testval)
 	sock.Destroy()
 }
 
 func TestConflate(t *testing.T) {
-	sock := NewSock(PUSH)
+	sock := NewSock(Push)
 	testval := 1
 	sock.SetConflate(testval)
 	sock.Destroy()
 }
 
 func TestZapDomain(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetZapDomain(testval)
 	val := sock.ZapDomain()
@@ -87,7 +85,7 @@ func TestZapDomain(t *testing.T) {
 }
 
 func TestPlainServer(t *testing.T) {
-	sock := NewSock(PUB)
+	sock := NewSock(Pub)
 	testval := 1
 	sock.SetPlainServer(testval)
 	val := sock.PlainServer()
@@ -98,7 +96,7 @@ func TestPlainServer(t *testing.T) {
 }
 
 func TestPlainUsername(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetPlainUsername(testval)
 	val := sock.PlainUsername()
@@ -109,7 +107,7 @@ func TestPlainUsername(t *testing.T) {
 }
 
 func TestPlainPassword(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetPlainPassword(testval)
 	val := sock.PlainPassword()
@@ -120,7 +118,7 @@ func TestPlainPassword(t *testing.T) {
 }
 
 func TestIpv6(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetIpv6(testval)
 	val := sock.Ipv6()
@@ -131,7 +129,7 @@ func TestIpv6(t *testing.T) {
 }
 
 func TestImmediate(t *testing.T) {
-	sock := NewSock(DEALER)
+	sock := NewSock(Dealer)
 	testval := 1
 	sock.SetImmediate(testval)
 	val := sock.Immediate()
@@ -142,14 +140,14 @@ func TestImmediate(t *testing.T) {
 }
 
 func TestRouterRaw(t *testing.T) {
-	sock := NewSock(ROUTER)
+	sock := NewSock(Router)
 	testval := 1
 	sock.SetRouterRaw(testval)
 	sock.Destroy()
 }
 
 func TestIpv4only(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetIpv4only(testval)
 	val := sock.Ipv4only()
@@ -160,14 +158,14 @@ func TestIpv4only(t *testing.T) {
 }
 
 func TestDelayAttachOnConnect(t *testing.T) {
-	sock := NewSock(PUB)
+	sock := NewSock(Pub)
 	testval := 1
 	sock.SetDelayAttachOnConnect(testval)
 	sock.Destroy()
 }
 
 func TestSndhwm(t *testing.T) {
-	sock := NewSock(PUB)
+	sock := NewSock(Pub)
 	testval := 1
 	sock.SetSndhwm(testval)
 	val := sock.Sndhwm()
@@ -178,7 +176,7 @@ func TestSndhwm(t *testing.T) {
 }
 
 func TestRcvhwm(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetRcvhwm(testval)
 	val := sock.Rcvhwm()
@@ -189,7 +187,7 @@ func TestRcvhwm(t *testing.T) {
 }
 
 func TestAffinity(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetAffinity(testval)
 	val := sock.Affinity()
@@ -200,21 +198,21 @@ func TestAffinity(t *testing.T) {
 }
 
 func TestSubscribe(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetSubscribe(testval)
 	sock.Destroy()
 }
 
 func TestUnsubscribe(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetUnsubscribe(testval)
 	sock.Destroy()
 }
 
 func TestIdentity(t *testing.T) {
-	sock := NewSock(DEALER)
+	sock := NewSock(Dealer)
 	testval := "test"
 	sock.SetIdentity(testval)
 	val := sock.Identity()
@@ -225,7 +223,7 @@ func TestIdentity(t *testing.T) {
 }
 
 func TestRate(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetRate(testval)
 	val := sock.Rate()
@@ -236,7 +234,7 @@ func TestRate(t *testing.T) {
 }
 
 func TestRecoveryIvl(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetRecoveryIvl(testval)
 	val := sock.RecoveryIvl()
@@ -247,7 +245,7 @@ func TestRecoveryIvl(t *testing.T) {
 }
 
 func TestSndbuf(t *testing.T) {
-	sock := NewSock(PUB)
+	sock := NewSock(Pub)
 	testval := 1
 	sock.SetSndbuf(testval)
 	val := sock.Sndbuf()
@@ -258,7 +256,7 @@ func TestSndbuf(t *testing.T) {
 }
 
 func TestRcvbuf(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetRcvbuf(testval)
 	val := sock.Rcvbuf()
@@ -269,7 +267,7 @@ func TestRcvbuf(t *testing.T) {
 }
 
 func TestLinger(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetLinger(testval)
 	val := sock.Linger()
@@ -280,7 +278,7 @@ func TestLinger(t *testing.T) {
 }
 
 func TestReconnectIvl(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetReconnectIvl(testval)
 	val := sock.ReconnectIvl()
@@ -291,7 +289,7 @@ func TestReconnectIvl(t *testing.T) {
 }
 
 func TestReconnectIvlMax(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetReconnectIvlMax(testval)
 	val := sock.ReconnectIvlMax()
@@ -302,7 +300,7 @@ func TestReconnectIvlMax(t *testing.T) {
 }
 
 func TestBacklog(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetBacklog(testval)
 	val := sock.Backlog()
@@ -313,7 +311,7 @@ func TestBacklog(t *testing.T) {
 }
 
 func TestMaxmsgsize(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetMaxmsgsize(testval)
 	val := sock.Maxmsgsize()
@@ -324,7 +322,7 @@ func TestMaxmsgsize(t *testing.T) {
 }
 
 func TestMulticastHops(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetMulticastHops(testval)
 	val := sock.MulticastHops()
@@ -335,7 +333,7 @@ func TestMulticastHops(t *testing.T) {
 }
 
 func TestRcvtimeo(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetRcvtimeo(testval)
 	val := sock.Rcvtimeo()
@@ -346,7 +344,7 @@ func TestRcvtimeo(t *testing.T) {
 }
 
 func TestSndtimeo(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetSndtimeo(testval)
 	val := sock.Sndtimeo()
@@ -357,14 +355,14 @@ func TestSndtimeo(t *testing.T) {
 }
 
 func TestXpubVerbose(t *testing.T) {
-	sock := NewSock(XPUB)
+	sock := NewSock(XPub)
 	testval := 1
 	sock.SetXpubVerbose(testval)
 	sock.Destroy()
 }
 
 func TestTcpKeepalive(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetTcpKeepalive(testval)
 	val := sock.TcpKeepalive()
@@ -375,7 +373,7 @@ func TestTcpKeepalive(t *testing.T) {
 }
 
 func TestTcpKeepaliveIdle(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetTcpKeepaliveIdle(testval)
 	val := sock.TcpKeepaliveIdle()
@@ -386,7 +384,7 @@ func TestTcpKeepaliveIdle(t *testing.T) {
 }
 
 func TestTcpKeepaliveCnt(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetTcpKeepaliveCnt(testval)
 	val := sock.TcpKeepaliveCnt()
@@ -397,7 +395,7 @@ func TestTcpKeepaliveCnt(t *testing.T) {
 }
 
 func TestTcpKeepaliveIntvl(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := 1
 	sock.SetTcpKeepaliveIntvl(testval)
 	val := sock.TcpKeepaliveIntvl()
@@ -408,7 +406,7 @@ func TestTcpKeepaliveIntvl(t *testing.T) {
 }
 
 func TestTcpAcceptFilter(t *testing.T) {
-	sock := NewSock(SUB)
+	sock := NewSock(Sub)
 	testval := "127.0.0.1"
 	sock.SetTcpAcceptFilter(testval)
 	val := sock.TcpAcceptFilter()
@@ -417,3 +415,4 @@ func TestTcpAcceptFilter(t *testing.T) {
 	}
 	sock.Destroy()
 }
+

--- a/sock_option_test.gsl
+++ b/sock_option_test.gsl
@@ -31,7 +31,7 @@ import (
 .if mode = "rw" | mode = "w"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 func Test$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:upper))
+	sock := NewSock($(test:pascal))
 	testval := $(test_value?'1':)
 	sock.Set$(name:pascal)(testval)
 .if mode = "rw"
@@ -46,7 +46,7 @@ func Test$(name:pascal)(t *testing.T) {
 .endif
 .if type = "string" | type = "key"
 func Test$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:upper))
+	sock := NewSock($(test:pascal))
 	testval := "$(test_value?'test':)"
 	sock.Set$(name:pascal)(testval)
 .if mode = "rw"
@@ -62,7 +62,7 @@ func Test$(name:pascal)(t *testing.T) {
 .if mode = "r"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 func Test$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:upper))
+	sock := NewSock($(test:pascal))
 	_ = sock.$(name:pascal)()
 	sock.Destroy()
 }
@@ -70,7 +70,7 @@ func Test$(name:pascal)(t *testing.T) {
 .endif
 .if type = "string" | type = "key"
 func Test$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:upper))
+	sock := NewSock($(test:pascal))
 	_ = sock.$(name:pascal)()
 	sock.Destroy()
 }

--- a/sock_test.go
+++ b/sock_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestSendFrame(t *testing.T) {
-	pushSock := NewSock(PUSH)
+	pushSock := NewSock(Push)
 	defer pushSock.Destroy()
 
-	pullSock := NewSock(PULL)
+	pullSock := NewSock(Pull)
 	defer pullSock.Destroy()
 
 	_, err := pullSock.Bind("inproc://test-sock")
@@ -67,10 +67,10 @@ func TestSendFrame(t *testing.T) {
 }
 
 func TestSendEmptyFrame(t *testing.T) {
-	pushSock := NewSock(PUSH)
+	pushSock := NewSock(Push)
 	defer pushSock.Destroy()
 
-	pullSock := NewSock(PULL)
+	pullSock := NewSock(Pull)
 	defer pullSock.Destroy()
 
 	_, err := pullSock.Bind("inproc://test-sock")
@@ -100,10 +100,10 @@ func TestSendEmptyFrame(t *testing.T) {
 }
 
 func TestSendMessage(t *testing.T) {
-	pushSock := NewSock(PUSH)
+	pushSock := NewSock(Push)
 	defer pushSock.Destroy()
 
-	pullSock := NewSock(PULL)
+	pullSock := NewSock(Pull)
 	defer pullSock.Destroy()
 
 	_, err := pullSock.Bind("inproc://test-sock")
@@ -142,26 +142,26 @@ func TestSendMessage(t *testing.T) {
 	}
 }
 
-func TestPUBSUB(t *testing.T) {
-	_, err := NewPUB("bogus://bogus")
+func TestPubSub(t *testing.T) {
+	_, err := NewPub("bogus://bogus")
 	if err == nil {
-		t.Error("NewPUB should have returned error and did not")
+		t.Error("NewPub should have returned error and did not")
 	}
 
-	_, err = NewSUB("bogus://bogus", "")
+	_, err = NewSub("bogus://bogus", "")
 	if err == nil {
-		t.Error("NewSUB should have returned error and did not")
+		t.Error("NewSub should have returned error and did not")
 	}
 
-	pub, err := NewPUB("inproc://pub1,inproc://pub2")
+	pub, err := NewPub("inproc://pub1,inproc://pub2")
 	if err != nil {
-		t.Errorf("NewPUB failed: %s", err)
+		t.Errorf("NewPub failed: %s", err)
 	}
 	defer pub.Destroy()
 
-	sub, err := NewSUB("inproc://pub1,inproc://pub2", "")
+	sub, err := NewSub("inproc://pub1,inproc://pub2", "")
 	if err != nil {
-		t.Errorf("NewSUB failed: %s", err)
+		t.Errorf("NewSub failed: %s", err)
 	}
 	defer sub.Destroy()
 
@@ -180,26 +180,26 @@ func TestPUBSUB(t *testing.T) {
 	}
 }
 
-func TestREQREP(t *testing.T) {
-	_, err := NewREQ("bogus://bogus")
+func TestReqRep(t *testing.T) {
+	_, err := NewReq("bogus://bogus")
 	if err == nil {
-		t.Error("NewREQ should have returned error and did not")
+		t.Error("NewReq should have returned error and did not")
 	}
 
-	_, err = NewREP("bogus://bogus")
+	_, err = NewRep("bogus://bogus")
 	if err == nil {
-		t.Error("NewREP should have returned error and did not")
+		t.Error("NewRep should have returned error and did not")
 	}
 
-	rep, err := NewREP("inproc://rep1,inproc://rep2")
+	rep, err := NewRep("inproc://rep1,inproc://rep2")
 	if err != nil {
-		t.Errorf("NewREP failed: %s", err)
+		t.Errorf("NewRep failed: %s", err)
 	}
 	defer rep.Destroy()
 
-	req, err := NewREQ("inproc://rep1,inproc://rep2")
+	req, err := NewReq("inproc://rep1,inproc://rep2")
 	if err != nil {
-		t.Errorf("NewREQ failed: %s", err)
+		t.Errorf("NewReq failed: %s", err)
 	}
 	defer req.Destroy()
 
@@ -233,26 +233,26 @@ func TestREQREP(t *testing.T) {
 
 }
 
-func TestPUSHPULL(t *testing.T) {
-	_, err := NewPUSH("bogus://bogus")
+func TestPushPull(t *testing.T) {
+	_, err := NewPush("bogus://bogus")
 	if err == nil {
-		t.Error("NewPUSH should have returned error and did not")
+		t.Error("NewPush should have returned error and did not")
 	}
 
-	_, err = NewPULL("bogus://bogus")
+	_, err = NewPull("bogus://bogus")
 	if err == nil {
-		t.Error("NewPULL should have returned error and did not")
+		t.Error("NewPull should have returned error and did not")
 	}
 
-	push, err := NewPUSH("inproc://push1,inproc://push2")
+	push, err := NewPush("inproc://push1,inproc://push2")
 	if err != nil {
-		t.Errorf("NewPUSH failed: %s", err)
+		t.Errorf("NewPush failed: %s", err)
 	}
 	defer push.Destroy()
 
-	pull, err := NewPULL("inproc://push1,inproc://push2")
+	pull, err := NewPull("inproc://push1,inproc://push2")
 	if err != nil {
-		t.Errorf("NewPULL failed: %s", err)
+		t.Errorf("NewPull failed: %s", err)
 	}
 	defer pull.Destroy()
 
@@ -280,26 +280,26 @@ func TestPUSHPULL(t *testing.T) {
 	}
 }
 
-func TestROUTERDEALER(t *testing.T) {
-	_, err := NewDEALER("bogus://bogus")
+func TestRouterDealer(t *testing.T) {
+	_, err := NewDealer("bogus://bogus")
 	if err == nil {
-		t.Error("NewDEALER should have returned error and did not")
+		t.Error("NewDealer should have returned error and did not")
 	}
 
-	_, err = NewROUTER("bogus://bogus")
+	_, err = NewRouter("bogus://bogus")
 	if err == nil {
-		t.Error("NewROUTER should have returned error and did not")
+		t.Error("NewRouter should have returned error and did not")
 	}
 
-	dealer, err := NewDEALER("inproc://router1,inproc://router2")
+	dealer, err := NewDealer("inproc://router1,inproc://router2")
 	if err != nil {
-		t.Errorf("NewDEALER failed: %s", err)
+		t.Errorf("NewDealer failed: %s", err)
 	}
 	defer dealer.Destroy()
 
-	router, err := NewROUTER("inproc://router1,inproc://router2")
+	router, err := NewRouter("inproc://router1,inproc://router2")
 	if err != nil {
-		t.Errorf("NewROUTER failed: %s", err)
+		t.Errorf("NewRouter failed: %s", err)
 	}
 	defer router.Destroy()
 
@@ -341,79 +341,79 @@ func TestROUTERDEALER(t *testing.T) {
 	}
 }
 
-func TestXSUBXPUB(t *testing.T) {
-	_, err := NewXPUB("bogus://bogus")
+func TestXSubXPub(t *testing.T) {
+	_, err := NewXPub("bogus://bogus")
 	if err == nil {
-		t.Error("NewXPUB should have returned error and did not")
+		t.Error("NewXPub should have returned error and did not")
 	}
 
-	_, err = NewXSUB("bogus://bogus")
+	_, err = NewXSub("bogus://bogus")
 	if err == nil {
-		t.Error("NewXSUB should have returned error and did not")
+		t.Error("NewXSub should have returned error and did not")
 	}
 
-	xpub, err := NewXPUB("inproc://xpub1,inproc://xpub2")
+	xpub, err := NewXPub("inproc://xpub1,inproc://xpub2")
 	if err != nil {
-		t.Errorf("NewXPUB failed: %s", err)
+		t.Errorf("NewXPub failed: %s", err)
 	}
 	defer xpub.Destroy()
 
-	xsub, err := NewXSUB("inproc://xpub1,inproc://xpub2")
+	xsub, err := NewXSub("inproc://xpub1,inproc://xpub2")
 	if err != nil {
-		t.Errorf("NewXSUB failed: %s", err)
+		t.Errorf("NewXSub failed: %s", err)
 	}
 	defer xsub.Destroy()
 }
 
-func TestPAIR(t *testing.T) {
-	_, err := NewPAIR("bogus://bogus")
+func TestPair(t *testing.T) {
+	_, err := NewPair("bogus://bogus")
 	if err == nil {
-		t.Error("NewPAIR should have returned error and did not")
+		t.Error("NewPair should have returned error and did not")
 	}
 
-	pair1, err := NewPAIR(">inproc://pair")
+	pair1, err := NewPair(">inproc://pair")
 	if err != nil {
-		t.Errorf("NewPAIR failed: %s", err)
+		t.Errorf("NewPair failed: %s", err)
 	}
 	defer pair1.Destroy()
 
-	pair2, err := NewPAIR("@inproc://pair")
+	pair2, err := NewPair("@inproc://pair")
 	if err != nil {
-		t.Errorf("NewPAIR failed: %s", err)
+		t.Errorf("NewPair failed: %s", err)
 	}
 	defer pair2.Destroy()
 }
 
-func TestSTREAM(t *testing.T) {
-	_, err := NewSTREAM("bogus://bogus")
+func TestStream(t *testing.T) {
+	_, err := NewStream("bogus://bogus")
 	if err == nil {
-		t.Error("NewSTREAM should have returned error and did not")
+		t.Error("NewStream should have returned error and did not")
 	}
 
-	stream1, err := NewSTREAM(">inproc://stream")
+	stream1, err := NewStream(">inproc://stream")
 	if err != nil {
-		t.Errorf("NewSTREAM failed: %s", err)
+		t.Errorf("NewStream failed: %s", err)
 	}
 	defer stream1.Destroy()
 
-	stream2, err := NewSTREAM("@inproc://stream")
+	stream2, err := NewStream("@inproc://stream")
 	if err != nil {
-		t.Errorf("NewSTREAM failed: %s", err)
+		t.Errorf("NewStream failed: %s", err)
 	}
 	defer stream2.Destroy()
 
 }
 
 func TestPollin(t *testing.T) {
-	push, err := NewPUSH("inproc://pollin")
+	push, err := NewPush("inproc://pollin")
 	if err != nil {
-		t.Errorf("NewPUSH failed: %s", err)
+		t.Errorf("NewPush failed: %s", err)
 	}
 	defer push.Destroy()
 
-	pull, err := NewPULL("inproc://pollin")
+	pull, err := NewPull("inproc://pollin")
 	if err != nil {
-		t.Errorf("NewPULL failed: %s", err)
+		t.Errorf("NewPull failed: %s", err)
 	}
 	defer pull.Destroy()
 
@@ -432,7 +432,7 @@ func TestPollin(t *testing.T) {
 }
 
 func TestPollout(t *testing.T) {
-	push := NewSock(PUSH)
+	push := NewSock(Push)
 	_, err := push.Bind("inproc://pollout")
 	if err != nil {
 		t.Errorf("failed binding test socket: %s", err)
@@ -443,7 +443,7 @@ func TestPollout(t *testing.T) {
 		t.Errorf("Pollout returned true should be false")
 	}
 
-	pull := NewSock(PULL)
+	pull := NewSock(Pull)
 	defer pull.Destroy()
 
 	err = pull.Connect("inproc://pollout")
@@ -457,10 +457,10 @@ func TestPollout(t *testing.T) {
 }
 
 func TestReader(t *testing.T) {
-	pushSock := NewSock(PUSH)
+	pushSock := NewSock(Push)
 	defer pushSock.Destroy()
 
-	pullSock := NewSock(PULL)
+	pullSock := NewSock(Pull)
 	defer pullSock.Destroy()
 
 	_, err := pullSock.Bind("inproc://test-read")
@@ -515,10 +515,10 @@ func TestReader(t *testing.T) {
 }
 
 func TestReaderWithRouterDealer(t *testing.T) {
-	dealerSock := NewSock(DEALER)
+	dealerSock := NewSock(Dealer)
 	defer dealerSock.Destroy()
 
-	routerSock := NewSock(ROUTER)
+	routerSock := NewSock(Router)
 	defer routerSock.Destroy()
 
 	_, err := routerSock.Bind("inproc://test-read")
@@ -590,13 +590,13 @@ func TestReaderWithRouterDealer(t *testing.T) {
 }
 
 func TestReaderWithRouterDealerAsync(t *testing.T) {
-	dealerSock1 := NewSock(DEALER)
+	dealerSock1 := NewSock(Dealer)
 	defer dealerSock1.Destroy()
 
-	dealerSock2 := NewSock(DEALER)
+	dealerSock2 := NewSock(Dealer)
 	defer dealerSock2.Destroy()
 
-	routerSock := NewSock(ROUTER)
+	routerSock := NewSock(Router)
 	defer routerSock.Destroy()
 
 	_, err := routerSock.Bind("inproc://test-read")
@@ -680,12 +680,12 @@ func TestReaderWithRouterDealerAsync(t *testing.T) {
 }
 
 func ExampleSock_output() {
-	dealer, err := NewDEALER("inproc://example")
+	dealer, err := NewDealer("inproc://example")
 	if err != nil {
 		panic(err)
 	}
 
-	router, err := NewROUTER("inproc://example")
+	router, err := NewRouter("inproc://example")
 	if err != nil {
 		panic(err)
 	}

--- a/sockopts.xml
+++ b/sockopts.xml
@@ -7,41 +7,41 @@
 <options script = "sockopts">
     <version major = "4" style = "macro">
         <!-- Options that are new in 4.1 -->
-        <option name = "tos"               type = "int"    mode = "rw" test = "DEALER" />
-        <option name = "router_handover"   type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
+        <option name = "tos"               type = "int"    mode = "rw" test = "Dealer" />
+        <option name = "router_handover"   type = "int"    mode = "w"  test = "Router">
+            <restrict type = "Router" />
         </option>
         
         <!-- Options that are new in 4.0 -->
-        <option name = "router_mandatory"  type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
+        <option name = "router_mandatory"  type = "int"    mode = "w"  test = "Router">
+            <restrict type = "Router" />
         </option>
-        <option name = "probe_router"      type = "int"    mode = "w"  test = "DEALER">
-            <restrict type = "ROUTER" />
-            <restrict type = "DEALER" />
-            <restrict type = "REQ" />
+        <option name = "probe_router"      type = "int"    mode = "w"  test = "Dealer">
+            <restrict type = "Router" />
+            <restrict type = "Dealer" />
+            <restrict type = "Req" />
         </option>
-        <option name = "req_relaxed"       type = "int"    mode = "w"  test = "REQ">
-            <restrict type = "REQ" />
+        <option name = "req_relaxed"       type = "int"    mode = "w"  test = "Req">
+            <restrict type = "Req" />
         </option>
-        <option name = "req_correlate"     type = "int"    mode = "w"  test = "REQ">
-            <restrict type = "REQ" />
+        <option name = "req_correlate"     type = "int"    mode = "w"  test = "Req">
+            <restrict type = "Req" />
         </option>
-        <option name = "conflate"          type = "int"    mode = "w"  test = "PUSH">
-            <restrict type = "PUSH" />
-            <restrict type = "PULL" />
-            <restrict type = "PUB" />
-            <restrict type = "SUB" />
-            <restrict type = "DEALER" />
+        <option name = "conflate"          type = "int"    mode = "w"  test = "Push">
+            <restrict type = "Push" />
+            <restrict type = "Pull" />
+            <restrict type = "Pub" />
+            <restrict type = "Sub" />
+            <restrict type = "Dealer" />
         </option>
         
         <!-- Security options -->
-        <option name = "zap_domain"        type = "string" mode = "rw" test = "SUB" />
-        <option name = "mechanism"         type = "int"    mode = "r"  test = "SUB" />
+        <option name = "zap_domain"        type = "string" mode = "rw" test = "Sub" />
+        <option name = "mechanism"         type = "int"    mode = "r"  test = "Sub" />
 
-        <option name = "plain_server"      type = "int"    mode = "rw" test = "PUB" />
-        <option name = "plain_username"    type = "string" mode = "rw" test = "SUB" />
-        <option name = "plain_password"    type = "string" mode = "rw" test = "SUB" />
+        <option name = "plain_server"      type = "int"    mode = "rw" test = "Pub" />
+        <option name = "plain_username"    type = "string" mode = "rw" test = "Sub" />
+        <option name = "plain_password"    type = "string" mode = "rw" test = "Sub" />
 
         <!-- We don't test these as libzmq doesn't always support CURVE security -->
         <option name = "curve_server"      type = "int"    mode = "rw" />
@@ -57,16 +57,16 @@
                                            type = "string" mode = "rw" />
 
         <!-- New names for deprecated 3.x options -->
-        <option name = "ipv6"              type = "int"    mode = "rw" test = "SUB" />
-        <option name = "immediate"         type = "int"    mode = "rw" test = "DEALER" />
+        <option name = "ipv6"              type = "int"    mode = "rw" test = "Sub" />
+        <option name = "immediate"         type = "int"    mode = "rw" test = "Dealer" />
 
         <!-- Deprecated 3.x options -->
-        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
+        <option name = "router_raw"        type = "int"    mode = "w"  test = "Router">
+            <restrict type = "Router" />
         </option>
-        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "ipv4only"          type = "int"    mode = "rw" test = "Sub" />
         <option name = "delay_attach_on_connect"
-                                           type = "int"    mode = "w"  test = "PUB" />
+                                           type = "int"    mode = "w"  test = "Pub" />
 
         <!-- Options that are the same in 3.x -->
         <include name = "3-x options" />
@@ -77,87 +77,87 @@
         <include name = "3-x options" />
         
         <!-- Options that are deprecated in 4.0 -->
-        <option name = "router_raw"        type = "int"    mode = "w"  test = "ROUTER">
-            <restrict type = "ROUTER" />
+        <option name = "router_raw"        type = "int"    mode = "w"  test = "Router">
+            <restrict type = "Router" />
         </option>
-        <option name = "ipv4only"          type = "int"    mode = "rw" test = "SUB" />
+        <option name = "ipv4only"          type = "int"    mode = "rw" test = "Sub" />
         <option name = "delay_attach_on_connect"
-                                           type = "int"    mode = "w"  test = "PUB" />
+                                           type = "int"    mode = "w"  test = "Pub" />
     </version>
 
     <!-- Legacy version 2 -->
     <version major = "2" style = "macro">
-        <option name = "hwm"               type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "swap"              type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "identity"          type = "string" mode = "rw" test = "SUB" />
-        <option name = "rate"              type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
-        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" minor = "2" />
-        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
-        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
+        <option name = "hwm"               type = "uint64" mode = "rw" test = "Sub" />
+        <option name = "swap"              type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "affinity"          type = "uint64" mode = "rw" test = "Sub" />
+        <option name = "identity"          type = "string" mode = "rw" test = "Sub" />
+        <option name = "rate"              type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "recovery_ivl"      type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "recovery_ivl_msec" type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "mcast_loop"        type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "Sub" minor = "2" />
+        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "Sub" minor = "2" />
+        <option name = "sndbuf"            type = "uint64" mode = "rw" test = "Sub" />
+        <option name = "rcvbuf"            type = "uint64" mode = "rw" test = "Sub" />
+        <option name = "linger"            type = "int"    mode = "rw" test = "Sub" />
+        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "Sub" />
+        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "Sub" />
+        <option name = "backlog"           type = "int"    mode = "rw" test = "Sub" />
+        <option name = "subscribe"         type = "string" mode = "w"  test = "Sub">
+            <restrict type = "Sub" />
         </option>
-        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
+        <option name = "unsubscribe"       type = "string" mode = "w"  test = "Sub">
+            <restrict type = "Sub" />
         </option>
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
-        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "SUB" />
-        <option name = "fd"                type = "int"    mode = "r"  test = "SUB" />
-        <option name = "events"            type = "uint32" mode = "r"  test = "SUB" />
+        <option name = "type"              type = "int"    mode = "r"  test = "Sub" />
+        <option name = "rcvmore"           type = "int64"  mode = "r"  test = "Sub" />
+        <option name = "fd"                type = "int"    mode = "r"  test = "Sub" />
+        <option name = "events"            type = "uint32" mode = "r"  test = "Sub" />
     </version>
     
     <macro name = "3-x options">
-        <option name = "type"              type = "int"    mode = "r"  test = "SUB" />
-        <option name = "sndhwm"            type = "int"    mode = "rw" test = "PUB" />
-        <option name = "rcvhwm"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "affinity"          type = "uint64" mode = "rw" test = "SUB" />
-        <option name = "subscribe"         type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
+        <option name = "type"              type = "int"    mode = "r"  test = "Sub" />
+        <option name = "sndhwm"            type = "int"    mode = "rw" test = "Pub" />
+        <option name = "rcvhwm"            type = "int"    mode = "rw" test = "Sub" />
+        <option name = "affinity"          type = "uint64" mode = "rw" test = "Sub" />
+        <option name = "subscribe"         type = "string" mode = "w"  test = "Sub">
+            <restrict type = "Sub" />
         </option>
-        <option name = "unsubscribe"       type = "string" mode = "w"  test = "SUB">
-            <restrict type = "SUB" />
+        <option name = "unsubscribe"       type = "string" mode = "w"  test = "Sub">
+            <restrict type = "Sub" />
         </option>
-        <option name = "identity"          type = "string" mode = "rw" test = "DEALER">
-            <restrict type = "REQ" />
-            <restrict type = "REP" />
-            <restrict type = "DEALER" />
-            <restrict type = "ROUTER" />
+        <option name = "identity"          type = "string" mode = "rw" test = "Dealer">
+            <restrict type = "Req" />
+            <restrict type = "Rep" />
+            <restrict type = "Dealer" />
+            <restrict type = "Router" />
         </option>
-        <option name = "rate"              type = "int"    mode = "rw" test = "SUB" />
-        <option name = "recovery_ivl"      type = "int"    mode = "rw" test = "SUB" />
-        <option name = "sndbuf"            type = "int"    mode = "rw" test = "PUB" />
-        <option name = "rcvbuf"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "linger"            type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "SUB" />
-        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "SUB" />
-        <option name = "backlog"           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "maxmsgsize"        type = "int64"  mode = "rw" test = "SUB" />
-        <option name = "multicast_hops"    type = "int"    mode = "rw" test = "SUB" />
-        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "SUB" />
-        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "SUB" />
-        <option name = "xpub_verbose"      type = "int"    mode = "w"  test = "XPUB">
-            <restrict type = "XPUB" />
+        <option name = "rate"              type = "int"    mode = "rw" test = "Sub" />
+        <option name = "recovery_ivl"      type = "int"    mode = "rw" test = "Sub" />
+        <option name = "sndbuf"            type = "int"    mode = "rw" test = "Pub" />
+        <option name = "rcvbuf"            type = "int"    mode = "rw" test = "Sub" />
+        <option name = "linger"            type = "int"    mode = "rw" test = "Sub" />
+        <option name = "reconnect_ivl"     type = "int"    mode = "rw" test = "Sub" />
+        <option name = "reconnect_ivl_max" type = "int"    mode = "rw" test = "Sub" />
+        <option name = "backlog"           type = "int"    mode = "rw" test = "Sub" />
+        <option name = "maxmsgsize"        type = "int64"  mode = "rw" test = "Sub" />
+        <option name = "multicast_hops"    type = "int"    mode = "rw" test = "Sub" />
+        <option name = "rcvtimeo"          type = "int"    mode = "rw" test = "Sub" />
+        <option name = "sndtimeo"          type = "int"    mode = "rw" test = "Sub" />
+        <option name = "xpub_verbose"      type = "int"    mode = "w"  test = "XPub">
+            <restrict type = "XPub" />
         </option>
-        <option name = "tcp_keepalive"     type = "int"    mode = "rw" test = "SUB" />
+        <option name = "tcp_keepalive"     type = "int"    mode = "rw" test = "Sub" />
         <option name = "tcp_keepalive_idle"
-                                           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "tcp_keepalive_cnt" type = "int"    mode = "rw" test = "SUB" />
+                                           type = "int"    mode = "rw" test = "Sub" />
+        <option name = "tcp_keepalive_cnt" type = "int"    mode = "rw" test = "Sub" />
         <option name = "tcp_keepalive_intvl"
-                                           type = "int"    mode = "rw" test = "SUB" />
-        <option name = "tcp_accept_filter" type = "string" mode = "rw" test = "SUB"
+                                           type = "int"    mode = "rw" test = "Sub" />
+        <option name = "tcp_accept_filter" type = "string" mode = "rw" test = "Sub"
                 test_value = "127.0.0.1" />
-        <option name = "rcvmore"           type = "int"    mode = "r"  test = "SUB" />
-        <option name = "fd"                type = "int"    mode = "r"  test = "SUB" />
-        <option name = "events"            type = "int"    mode = "r"  test = "SUB" />
-        <option name = "last_endpoint"     type = "string" mode = "r"  test = "SUB" />
+        <option name = "rcvmore"           type = "int"    mode = "r"  test = "Sub" />
+        <option name = "fd"                type = "int"    mode = "r"  test = "Sub" />
+        <option name = "events"            type = "int"    mode = "r"  test = "Sub" />
+        <option name = "last_endpoint"     type = "string" mode = "r"  test = "Sub" />
     </macro>
 </options>


### PR DESCRIPTION
All caps identifiers for some constants and functions did not follow go naming conventions, making code weird to read for go developers.  This pull request fixes that in preparation for our stable release.

Please note that this is a non backwards compatible change.  Apologies for that but Luna and I discussed it - the refactor is easy (simple renaming some things) and is worth the cost.

We are targeting "stable" to be declared to coincide with the CZMQ 3.0 release.  This PR should be the last breaking change to prepare for that.



