### PR TITLE
Problem: channeler implementation used sockets unsafely across threads

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -1,121 +1,69 @@
 package goczmq
 
-import (
-	"testing"
-	"time"
-)
+import "testing"
 
-func TestChanneler(t *testing.T) {
-	d2 := NewSock(Pair)
-	_, err := d2.Bind("inproc://channeler-test")
-	if err != nil {
-		t.Errorf("Error creating d2: %s", err)
-		return
+func TestPushPullChanneler(t *testing.T) {
+	push := NewPushChanneler("inproc://channelerpushpull")
+	defer push.Destroy()
+
+	pull := NewPullChanneler("inproc://channelerpushpull")
+	defer pull.Destroy()
+
+	push.SendChan <- [][]byte{[]byte("hello")}
+	resp := <-pull.RecvChan
+	if string(resp[0]) != "hello" {
+		t.Errorf("failed")
 	}
 
-	d1 := NewSock(Pair)
-	if err != nil {
-		t.Errorf("Error creating d1: %s", err)
-		return
+	push.SendChan <- [][]byte{[]byte("world")}
+	resp = <-pull.RecvChan
+	if string(resp[0]) != "world" {
+		t.Errorf("failed")
 	}
-
-	c := NewChanneler(d1, false)
-	c.AttachChan <- "inproc://channeler-test"
-	c.SendChan <- [][]byte{[]byte("ready")}
-
-	m, err := d2.RecvMessage()
-	if string(m[0]) != "ready" {
-		t.Errorf("Expected 'ready' but got %s", m)
-		return
-	}
-
-	// The channeler listens on d1, do a send on d2 and verify the receive
-	// channel of the channeler gets it
-	err = d2.SendFrame([]byte("Test"), 0)
-	if err != nil {
-		t.Errorf("d2.SendMessage failed: %s", err)
-		return
-	}
-
-	select {
-	case msg := <-c.RecvChan:
-		if string(msg[0]) != "Test" {
-			t.Error("Message received on receive channel mismatch")
-			return
-		}
-	case <-time.After(time.Millisecond * 250):
-		t.Error("Timeout while waiting for receive channel")
-		return
-	}
-
-	// Send a message through the channeler and verify d2 gets it
-	c.SendChan <- [][]byte{[]byte("Test")}
-	poller, err := NewPoller(d2)
-	if err != nil {
-		t.Errorf("Error while creating poller: %s", err)
-		return
-	}
-
-	s := poller.Wait(250)
-	if s == nil {
-		t.Error("Timeout while waiting for send channel")
-		return
-	}
-
-	msg, err := d2.RecvMessage()
-	if err != nil {
-		t.Errorf("Error while receiving message on d2: %s", err)
-		return
-	}
-
-	if string(msg[0]) != "Test" {
-		t.Error("Message received on d2 mismatch")
-		return
-	}
-
-	c.Close()
 }
 
-func ExampleChanneler() {
-	router := NewSock(Router)
-	routerChan := NewChanneler(router, false)
-	routerChan.AttachChan <- "inproc://channel_example"
+func TestDealerRouterChanneler(t *testing.T) {
+	dealer := NewDealerChanneler("inproc://channelerdealerrouter")
+	defer dealer.Destroy()
 
-	routerChan.Close()
+	router := NewRouterChanneler("inproc://channelerdealerrouter")
+	defer router.Destroy()
+
+	dealer.SendChan <- [][]byte{[]byte("hello")}
+	resp := <-router.RecvChan
+	if string(resp[1]) != "hello" {
+		t.Errorf("failed")
+	}
+
+	resp[1] = []byte("world")
+	router.SendChan <- resp
+
+	resp = <-dealer.RecvChan
+	if string(resp[0]) != "world" {
+		t.Errorf("failed")
+	}
 }
 
-func benchmarkChanneler(size int, b *testing.B) {
-	pullSock := NewSock(Pull)
-	pullSock.Bind("inproc://benchChan")
-	defer pullSock.Destroy()
-
-	channeler := NewChanneler(pullSock, false)
-	time.Sleep(10 * time.Millisecond)
+func BenchmarkChanneler(b *testing.B) {
 
 	go func() {
-		pushSock := NewSock(Push)
-		defer pushSock.Destroy()
-		err := pushSock.Connect("inproc://benchChan")
-		if err != nil {
-			panic(err)
-		}
+		push := NewPushChanneler("inproc://channelerbench")
+		defer push.Destroy()
 
-		payload := make([]byte, size)
+		payload := make([]byte, 1024)
+
 		for i := 0; i < b.N; i++ {
-			_, err = pushSock.Write(payload)
-			if err != nil {
-				panic(err)
-			}
+			push.SendChan <- [][]byte{payload}
 		}
 	}()
 
+	pull := NewPullChanneler("inproc://channelerbench")
+	defer pull.Destroy()
+
 	for i := 0; i < b.N; i++ {
-		msg := <-channeler.RecvChan
-		if len(msg[0]) != size {
-			panic("msg too small")
+		msg := <-pull.RecvChan
+		if len(msg[0]) != 1024 {
+			panic("message is corrupt")
 		}
 	}
-	channeler.Close()
 }
-
-func BenchmarkChanneler1k(b *testing.B) { benchmarkChanneler(1024, b) }

--- a/channeler_test.go
+++ b/channeler_test.go
@@ -45,9 +45,11 @@ func TestDealerRouterChanneler(t *testing.T) {
 }
 
 func BenchmarkChanneler(b *testing.B) {
+	pull := NewPullChanneler("inproc://benchchanneler")
+	defer pull.Destroy()
 
 	go func() {
-		push := NewPushChanneler("inproc://channelerbench")
+		push := NewPushChanneler("inproc://benchchanneler")
 		defer push.Destroy()
 
 		payload := make([]byte, 1024)
@@ -56,9 +58,6 @@ func BenchmarkChanneler(b *testing.B) {
 			push.SendChan <- [][]byte{payload}
 		}
 	}()
-
-	pull := NewPullChanneler("inproc://channelerbench")
-	defer pull.Destroy()
 
 	for i := 0; i < b.N; i++ {
 		msg := <-pull.RecvChan

--- a/goczmq.go
+++ b/goczmq.go
@@ -43,8 +43,9 @@ const (
 )
 
 var (
-	ErrActorCmd   = errors.New("error sending actor command")
-	ErrSockAttach = errors.New("error attaching zsock")
+	ErrActorCmd        = errors.New("error sending actor command")
+	ErrSockAttach      = errors.New("error attaching zsock")
+	ErrInvalidSockType = errors.New("invalid socket type")
 )
 
 func getStringType(k int) string {


### PR DESCRIPTION
Solution: Rework the channeler.  Channelers are now constructed by constructors similar to the "smart" socket constructors.  ZeroMQ sockets (and the related poller) are all created in the goroutine they are used in.  This is all similar in ways to a zactor from ZeroMQ, with an additional "hop" for commands from go channels to the command pipe.  This allows us to use the channeler in other channel select loops easily.

The extra "hop' for outbound messages does introduce a performance penalty over using sockets directly (around 4x), but there is future work that can be done to improve this.