### PR TITLE
Problem: channeler benchmark sometimes fails due to already bound endpoint

### DIFF
--- a/channeler_test.go
+++ b/channeler_test.go
@@ -2,6 +2,7 @@ package goczmq
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -77,11 +78,12 @@ func ExampleChanneler_output() {
 }
 
 func BenchmarkChanneler(b *testing.B) {
-	pull := NewPullChanneler("inproc://benchchanneler")
+	r := rand.Int63()
+	pull := NewPullChanneler("inproc://benchchanneler-%d", r)
 	defer pull.Destroy()
 
 	go func() {
-		push := NewPushChanneler("inproc://benchchanneler")
+		push := NewPushChanneler("inproc://benchchanneler-%d", r)
 		defer push.Destroy()
 
 		payload := make([]byte, 1024)

--- a/channeler_test.go
+++ b/channeler_test.go
@@ -79,11 +79,11 @@ func ExampleChanneler_output() {
 
 func BenchmarkChanneler(b *testing.B) {
 	r := rand.Int63()
-	pull := NewPullChanneler("inproc://benchchanneler-%d", r)
+	pull := NewPullChanneler(fmt.Sprintf("inproc://benchchanneler-%d", r))
 	defer pull.Destroy()
 
 	go func() {
-		push := NewPushChanneler("inproc://benchchanneler-%d", r)
+		push := NewPushChanneler(fmt.Sprintf("inproc://benchchanneler-%d", r))
 		defer push.Destroy()
 
 		payload := make([]byte, 1024)


### PR DESCRIPTION
Solution: add a little randomness to endpoint name