### PR TITLE
CertStore.Lookup now returns nil if no cert is found.

### DIFF
--- a/certstore.go
+++ b/certstore.go
@@ -31,8 +31,12 @@ func (c *CertStore) Insert(cert *Cert) {
 // Lookup looks up a certificate in the store by public key and
 // returns it.
 func (c *CertStore) Lookup(key string) *Cert {
+	ptr := C.zcertstore_lookup(c.zcertstoreT, C.CString(key))
+	if ptr == nil {
+		return nil
+	}
 	return &Cert{
-		zcertT: C.zcertstore_lookup(c.zcertstoreT, C.CString(key)),
+		zcertT: ptr,
 	}
 }
 

--- a/certstore_test.go
+++ b/certstore_test.go
@@ -12,6 +12,14 @@ func TestCertStore(t *testing.T) {
 	certstore := NewCertStore(testDir)
 	defer certstore.Destroy()
 
+	client0 := NewCert()
+	client0Key := client0.PublicText()
+	client0.Destroy()
+	client0Loaded := certstore.Lookup(client0Key)
+	if client0Loaded != nil {
+		t.Errorf("A Lookup of a cert that doesn't exist should return nil.")
+	}
+
 	client1 := NewCert()
 	client1.SetMeta("name", "Brian")
 	client1Key := client1.PublicText()


### PR DESCRIPTION
Prior behavior was that Lookup returned a Cert regardless of the
successful lookup. This caused a crash when doing things like this:

    cert := store.Lookup("nosuchclientkeything")
    cert.Print() // Crashed

Adds tests to cover the new behavior. No API change was made, just
behavioral change.