### PR TITLE
Problem: we can't see what versions of ZeroMQ and CZMQ we are on

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -43,6 +43,11 @@ const (
 	FlagNone     = 0
 
 	CurveAllowAny = "*"
+
+	ZMQVersionMajor  = int(C.ZMQ_VERSION_MAJOR)
+	ZMQVersionMinor  = int(C.ZMQ_VERSION_MINOR)
+	CZMQVersionMajor = int(C.CZMQ_VERSION_MAJOR)
+	CZMQVersionMinor = int(C.CZMQ_VERSION_MINOR)
 )
 
 var (


### PR DESCRIPTION
Solution: Expose the major and minor version constants for ZMQ and CZMQ.