### PR TITLE
Problem: Beacon should return address and beacon as single message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+warnings_are_errors: false
 
 go:
         - 1.4

--- a/beacon_test.go
+++ b/beacon_test.go
@@ -44,8 +44,9 @@ func TestBeacon(t *testing.T) {
 
 	speaker.Publish("HI", 100)
 
-	address := listener.Recv(500)
-	t.Logf("%v", address)
+	msg := listener.Recv(500)
+	t.Logf("Address: %s", string(msg[0]))
+	t.Logf("Beacon: %s", string(msg[1]))
 
 	listener.Destroy()
 	speaker.Destroy()


### PR DESCRIPTION
Details: See https://github.com/zeromq/goczmq/issues/151
Solution: Fix beacon to return address and beacon as single message

Note: this does change the return type of (b *Beacon) Recv(timeout int) from string to [][]byte.  In this case I believe the fix warrants this change as the original Recv call didn't match the Beacon implementation in CZMQ.  