### PR TITLE
returns void from Set_meta; fixes #158

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Indradhanush Gupta
 Armen Baghumian
 Ben Aldrich
 Jordan Sissel
+Nick Bargnesi

--- a/cert.go
+++ b/cert.go
@@ -3,7 +3,7 @@ package goczmq
 /*
 #include "czmq.h"
 
-int Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, value);}
+void Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, value);}
 */
 import "C"
 


### PR DESCRIPTION
zcert_set_meta returns void, so do the same in Set_meta