### PR TITLE
Problem: sock.Read should return read number of bytes not size of frames

### DIFF
--- a/sock.go
+++ b/sock.go
@@ -323,35 +323,37 @@ func (s *Sock) RecvMessage() ([][]byte, error) {
 
 // Read provides an io.Reader interface to a zeromq socket
 func (s *Sock) Read(p []byte) (int, error) {
-	var total int
+	var totalRead int
+	var totalFrame int
+
 	frame, flag, err := s.RecvFrame()
 	if err != nil {
-		return total, err
+		return totalRead, err
 	}
 
 	if s.GetType() == Router {
 		s.clientIDs = append(s.clientIDs, string(frame))
 	} else {
-		copy(p[:], frame[:])
-		total += len(frame)
+		totalRead += copy(p[:], frame[:])
+		totalFrame += len(frame)
 	}
 
 	for flag == FlagMore {
 		frame, flag, err = s.RecvFrame()
 		if err != nil {
-			return total, err
+			return totalRead, err
 		}
-		copy(p[total:], frame[:])
-		total += len(frame)
+		totalRead += copy(p[totalRead:], frame[:])
+		totalFrame += len(frame)
 	}
 
-	if total > len(p) {
+	if totalFrame > len(p) {
 		err = ErrSliceFull
 	} else {
 		err = nil
 	}
 
-	return total, err
+	return totalRead, err
 }
 
 // Write provides an io.Writer interface to a zeromq socket


### PR DESCRIPTION
This PR partially addresses https://github.com/zeromq/goczmq/issues/157 .

Read now returns the number of bytes read into the supplied byte array (p) properly.  In cases where p is too small to contain the full message, Read will return ErrSliceFull if p is too small to hold the message.  This is less than ideal - but the scope of changes required to allow multiple Read calls to consume a single message are much larger, as we would need to cache the frame between calls which we currently do not do.

So, for now we will fix Read to return the correct number of bytes, and to send a clear error message as to why Read is failing if p is too small.