### PR TITLE
Problem: sock_test.go did not pass golint

### DIFF
--- a/sock_test.go
+++ b/sock_test.go
@@ -84,7 +84,7 @@ func TestSendEmptyFrame(t *testing.T) {
 		t.Errorf("reqSock.Connect failed: %s", err)
 	}
 
-	empty := make([]byte, 0)
+	var empty []byte
 	err = pushSock.SendFrame(empty, FlagNone)
 	if err != nil {
 		t.Errorf("pushSock.SendFrame failed: %s", err)


### PR DESCRIPTION
Solution: fix it! Just a one line change to pass golint.  We like to pass golint, because attention to detail is important.