### PR TITLE
Problem: Sock io.ReadWriter cannot handle len(p) < len(Frame)

### DIFF
--- a/readwriter.go
+++ b/readwriter.go
@@ -1,0 +1,93 @@
+package goczmq
+
+import "C"
+
+// ReadWriter provides an io.ReadWriter compatible
+// interface for goczmq.Sock
+type ReadWriter struct {
+	sock      *Sock
+	clientIDs []string
+}
+
+// NewReadWriter accepts a sock and returns a goczmq.ReadWriter. The
+// io.ReadWriter should now be considered responsible for this
+// Sock.
+func NewReadWriter(sock *Sock) *ReadWriter {
+	return &ReadWriter{
+		sock:      sock,
+		clientIDs: make([]string, 0),
+	}
+}
+
+// Read satisifies io.Read
+func (r *ReadWriter) Read(p []byte) (int, error) {
+	var totalRead int
+	var totalFrame int
+
+	frame, flag, err := r.sock.RecvFrame()
+	if err != nil {
+		return totalRead, err
+	}
+
+	if r.sock.GetType() == Router {
+		r.clientIDs = append(r.clientIDs, string(frame))
+	} else {
+		totalRead += copy(p[:], frame[:])
+		totalFrame += len(frame)
+	}
+
+	for flag == FlagMore {
+		frame, flag, err = r.sock.RecvFrame()
+		if err != nil {
+			return totalRead, err
+		}
+		totalRead += copy(p[totalRead:], frame[:])
+		totalFrame += len(frame)
+	}
+
+	if totalFrame > len(p) {
+		err = ErrSliceFull
+	} else {
+		err = nil
+	}
+
+	return totalRead, err
+}
+
+// Write satisfies io.Write
+func (r *ReadWriter) Write(p []byte) (int, error) {
+	var total int
+	if r.sock.GetType() == Router {
+		err := r.sock.SendFrame(r.GetLastClientID(), FlagMore)
+		if err != nil {
+			return total, err
+		}
+	}
+	err := r.sock.SendFrame(p, 0)
+	if err != nil {
+		return total, err
+	}
+
+	return len(p), nil
+
+}
+
+// GetLastClientID returns the id of the last client you received
+// a message from if the underlying socket is a Router socket
+func (r *ReadWriter) GetLastClientID() []byte {
+	id := []byte(r.clientIDs[0])
+	r.clientIDs = r.clientIDs[1:]
+	return id
+}
+
+// SetLastClientID lets you manually set the id of the client
+// you last received a message from if the underlying socket
+// is a Router socket
+func (r *ReadWriter) SetLastClientID(id []byte) {
+	r.clientIDs = append(r.clientIDs, string(id))
+}
+
+// Destroy destroys both the ReadWriter and the underlying Sock
+func (r *ReadWriter) Destroy() {
+	r.sock.Destroy()
+}

--- a/readwriter_test.go
+++ b/readwriter_test.go
@@ -1,0 +1,265 @@
+package goczmq
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadWriter(t *testing.T) {
+	endpoint := "inproc://testReadWriter"
+
+	pushSock, err := NewPush(endpoint)
+	if err != nil {
+		t.Errorf("NewPush failed: %s", err)
+	}
+	defer pushSock.Destroy()
+
+	pullSock, err := NewPull(endpoint)
+	if err != nil {
+		t.Errorf("NewPull failed: %s", err)
+	}
+
+	pullReadWriter := NewReadWriter(pullSock)
+	defer pullReadWriter.Destroy()
+
+	err = pushSock.SendFrame([]byte("Hello"), FlagNone)
+	if err != nil {
+		t.Errorf("pushSock.SendFrame failed: %s", err)
+	}
+
+	b := make([]byte, 5)
+
+	n, err := pullReadWriter.Read(b)
+	if n != 5 {
+		t.Errorf("pullReadWriter.Read expected 5 bytes read %d", n)
+	}
+
+	if err != nil {
+		t.Errorf("pullReadWriter.Read error: %s", err)
+	}
+
+	if bytes.Compare(b, []byte("Hello")) != 0 {
+		t.Errorf("expected 'Hello' received '%s'", b)
+	}
+
+	err = pushSock.SendFrame([]byte("Hello"), FlagMore)
+	if err != nil {
+		t.Errorf("pushSock.SendFrame: %s", err)
+	}
+
+	err = pushSock.SendFrame([]byte(" World"), FlagNone)
+	if err != nil {
+		t.Errorf("pushSock.SendFrame: %s", err)
+	}
+
+	b = make([]byte, 8)
+	n, err = pullReadWriter.Read(b)
+	if err != ErrSliceFull {
+		t.Errorf("expected %s error, got %s", ErrSliceFull, err)
+	}
+
+	if bytes.Compare(b, []byte("Hello Wo")) != 0 {
+		t.Errorf("expected 'Hello Wo' received '%s'", b)
+	}
+}
+
+func TestReadWriterWithBufferSmallerThanFrame(t *testing.T) {
+	endpoint := "inproc://testReadWriterSmallBuf"
+
+	dealerSock, err := NewDealer(endpoint)
+	if err != nil {
+		t.Errorf("NewDealer failed: %s", err)
+	}
+	defer dealerSock.Destroy()
+
+	routerSock, err := NewRouter(endpoint)
+	if err != nil {
+		t.Errorf("NewRouter failed: %s", err)
+	}
+
+	routerReadWriter := NewReadWriter(routerSock)
+	defer routerReadWriter.Destroy()
+
+	err = dealerSock.SendFrame([]byte("Hello"), FlagNone)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame failed: %s", err)
+	}
+
+	b := make([]byte, 2)
+
+	n, err := routerReadWriter.Read(b)
+	if n != 2 {
+		t.Errorf("routerReadWriter.Read expected 2 bytes read %d", n)
+	}
+
+	if err != ErrSliceFull {
+		t.Errorf("routerReadWriter.Read expected io.EOF got %s", err)
+	}
+
+	if bytes.Compare(b, []byte("He")) != 0 {
+		t.Errorf("expected 'Hello' received '%s'", b)
+	}
+}
+
+func TestReadWriterWithRouterDealer(t *testing.T) {
+	endpoint := "inproc://testReadWriterWithRouterDealer"
+
+	dealerSock, err := NewDealer(endpoint)
+	if err != nil {
+		t.Errorf("NewDealer failed: %s", err)
+	}
+	defer dealerSock.Destroy()
+
+	routerSock, err := NewRouter(endpoint)
+	if err != nil {
+		t.Errorf("NewRouter failed: %s", err)
+	}
+
+	routerReadWriter := NewReadWriter(routerSock)
+	defer routerReadWriter.Destroy()
+
+	err = dealerSock.SendFrame([]byte("Hello"), FlagNone)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame failed: %s", err)
+	}
+
+	b := make([]byte, 5)
+
+	n, err := routerReadWriter.Read(b)
+	if n != 5 {
+		t.Errorf("routerReadWriter.Read expected 5 bytes read %d", n)
+	}
+
+	if err != nil {
+		t.Errorf("routerReadWriter.Read expected io.EOF got %s", err)
+	}
+
+	if bytes.Compare(b, []byte("Hello")) != 0 {
+		t.Errorf("expected 'Hello' received '%s'", b)
+	}
+
+	err = dealerSock.SendFrame([]byte("Hello"), FlagMore)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame: %s", err)
+	}
+
+	err = dealerSock.SendFrame([]byte(" World"), FlagNone)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame: %s", err)
+	}
+
+	b = make([]byte, 8)
+	n, err = routerReadWriter.Read(b)
+	if err != ErrSliceFull {
+		t.Errorf("expected %s error, got %s", ErrSliceFull, err)
+	}
+
+	if bytes.Compare(b, []byte("Hello Wo")) != 0 {
+		t.Errorf("expected 'Hello Wo' received '%s'", b)
+	}
+
+	n, err = routerReadWriter.Write([]byte("World"))
+	if err != nil {
+		t.Errorf("routerReadWriter.Write: %s", err)
+	}
+	if n != 5 {
+		t.Errorf("expected 5 bytes sent got %d", n)
+	}
+
+	frame, _, err := dealerSock.RecvFrame()
+	if err != nil {
+		t.Errorf("dealer.RecvFrame: %s", err)
+	}
+
+	if bytes.Compare(frame, []byte("World")) != 0 {
+		t.Errorf("expected 'World' received '%s'", b)
+	}
+}
+
+func TestReadWriterWithRouterDealerAsync(t *testing.T) {
+	endpoint := "inproc://testReadWriterWithRouterDealerAsync"
+
+	dealerSock1, err := NewDealer(endpoint)
+	if err != nil {
+		t.Errorf("NewDealer failed: %s", err)
+	}
+	defer dealerSock1.Destroy()
+
+	dealerSock2, err := NewDealer(endpoint)
+	if err != nil {
+		t.Errorf("NewDealer failed: %s", err)
+	}
+	defer dealerSock2.Destroy()
+
+	routerSock, err := NewRouter(endpoint)
+	if err != nil {
+		t.Errorf("NewRouter failed: %s", err)
+	}
+
+	routerReadWriter := NewReadWriter(routerSock)
+	defer routerReadWriter.Destroy()
+
+	err = dealerSock1.SendFrame([]byte("Hello From Client 1!"), FlagNone)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame failed: %s", err)
+	}
+
+	err = dealerSock2.SendFrame([]byte("Hello From Client 2!"), FlagNone)
+	if err != nil {
+		t.Errorf("dealerSock.SendFrame failed: %s", err)
+	}
+
+	msg := make([]byte, 255)
+
+	n, err := routerReadWriter.Read(msg)
+	if n != 20 {
+		t.Errorf("routerReadWriter.Read expected 20 bytes read %d", n)
+	}
+
+	client1ID := routerReadWriter.GetLastClientID()
+
+	if bytes.Compare(msg[:n], []byte("Hello From Client 1!")) != 0 {
+		t.Errorf("expected 'Hello From Client 1!' received '%s'", string(msg[:n]))
+	}
+
+	n, err = routerReadWriter.Read(msg)
+	if n != 20 {
+		t.Errorf("routerReadWriter.Read expected 20 bytes read %d", n)
+	}
+
+	client2ID := routerReadWriter.GetLastClientID()
+
+	if bytes.Compare(msg[:n], []byte("Hello From Client 2!")) != 0 {
+		t.Errorf("expected 'Hello From Client 2!' received '%s'", string(msg[:n]))
+	}
+
+	routerReadWriter.SetLastClientID(client1ID)
+	n, err = routerReadWriter.Write([]byte("Hello Client 1!"))
+	if err != nil {
+		t.Errorf("routerReadWriter.Write: %s", err)
+	}
+
+	frame, _, err := dealerSock1.RecvFrame()
+	if err != nil {
+		t.Errorf("dealer.RecvFrame: %s", err)
+	}
+
+	if bytes.Compare(frame, []byte("Hello Client 1!")) != 0 {
+		t.Errorf("expected 'World' received '%s'", frame)
+	}
+
+	routerReadWriter.SetLastClientID(client2ID)
+	n, err = routerReadWriter.Write([]byte("Hello Client 2!"))
+	if err != nil {
+		t.Errorf("routerReadWriter.Write: %s", err)
+	}
+
+	frame, _, err = dealerSock2.RecvFrame()
+	if err != nil {
+		t.Errorf("dealer.RecvFrame: %s", err)
+	}
+
+	if bytes.Compare(frame, []byte("Hello Client 2!")) != 0 {
+		t.Errorf("expected 'World' received '%s'", frame)
+	}
+}

--- a/sock.go
+++ b/sock.go
@@ -36,6 +36,7 @@ func init() {
 
 // GetLastClientID returns the id of the last client you received
 // a message from if the underlying socket is a Router socket
+// DEPRECATED: See goczmq.ReadWriter
 func (s *Sock) GetLastClientID() []byte {
 	id := []byte(s.clientIDs[0])
 	s.clientIDs = s.clientIDs[1:]
@@ -45,6 +46,7 @@ func (s *Sock) GetLastClientID() []byte {
 // SetLastClientID lets you manually set the id of the client
 // you last received a message from if the underlying socket
 // is a Router socket
+// DEPRECATED: See goczmq.ReadWriter
 func (s *Sock) SetLastClientID(id []byte) {
 	s.clientIDs = append(s.clientIDs, string(id))
 }
@@ -321,6 +323,7 @@ func (s *Sock) RecvMessage() ([][]byte, error) {
 }
 
 // Read provides an io.Reader interface to a zeromq socket
+// DEPRECATED: see goczmq.ReadWriter
 func (s *Sock) Read(p []byte) (int, error) {
 	var totalRead int
 	var totalFrame int
@@ -356,6 +359,7 @@ func (s *Sock) Read(p []byte) (int, error) {
 }
 
 // Write provides an io.Writer interface to a zeromq socket
+// DEPRECATED: See goczmq.ReadWriter
 func (s *Sock) Write(p []byte) (int, error) {
 	var total int
 	if s.GetType() == Router {


### PR DESCRIPTION
Solution: Create goczmq.ReadWriter, which will provide a more sophisticated io.ReadWriter interface that will handle this situation correctly while not breaking backwards compatibility.

This initial PR does the following:
* Adds goczmq.ReadWriter, which currently has the same limitations as sock.Read
* Marks sock.Read and sock.Write as DEPRECATED in the documentation. We will not remove these as we might break existing code that depends on goczmq

This gives us a place to make changes and go forward with solving this problem, while not breaking any existing API calls.  My plan is to add a buffer to ReadWriter that will allow Read to properly handle returning parts of a frame sequentially, so that multiple calls to ReadWriter.Read with a buffer smaller than a frame will do the right thing, returning an io.EOF once the end of the message is reached.

For more background, see: https://github.com/zeromq/goczmq/issues/157