### PR TITLE
Problem: ReadWriter.Read cannot handle len(p) < len(Frame)

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -132,6 +132,10 @@ var (
 	// ErrWaitAfterDestroy is returned by a Poller if there is an error
 	// accessing the underlying socket pointer when Wait is called
 	ErrWaitAfterDestroy = errors.New("Wait() is invalid on Poller after Destroy() is called.")
+
+	// ErrMultiPartUnsupported is returned when a function that does
+	// not support multi-part messages encounters a multi-part message
+	ErrMultiPartUnsupported = errors.New("function does not support multi part messages")
 )
 
 func getStringType(k int) string {


### PR DESCRIPTION
This PR finishes the initial support for ReadWriter.Read working with buffers that are smaller than the zmq message size.  Now, ReadWriter will cache the most recently read message until Read has been called enough times to read the entire message, at which point it will fetch the next message off the socket.

In the case of reading off of a ZMQ_ROUTER socket, the identity from the identity frame is read and held, and is accessible via GetLastCliendID.  SetLastClientID can be used to set the intended target for a Write call.

Note that this does not support multi part messages other than supporting identity frames when reading from a ZMQ_ROUTER socket.  This is intentional.  Read will return ErrMultiPartUnsupported when encountering a multi part message, defined as "a message with more than 2 frames when read from a ZMQ_ROUTER socket, or more than 1 frame from any other socket type".

This fixes https://github.com/zeromq/goczmq/issues/157