### PR TITLE
Problem: maintaining code that is not useful is not useful

### DIFF
--- a/readwriter_test.go
+++ b/readwriter_test.go
@@ -185,7 +185,7 @@ func TestReadWriterDoesNotSupportMultiPart(t *testing.T) {
 }
 
 func benchmarkReadWriter(size int, b *testing.B) {
-	endpoint := fmt.Sprintf("inproc://benchSockReadWriter%d", size)
+	endpoint := fmt.Sprintf("inproc://benchReadWriter%d", size)
 
 	pullSock, err := NewPull(endpoint)
 	if err != nil {
@@ -219,17 +219,14 @@ func benchmarkReadWriter(size int, b *testing.B) {
 
 	payload := make([]byte, size)
 	for i := 0; i < b.N; i++ {
-		n, err := pullReader.Read(payload)
+		_, err := pullReader.Read(payload)
 		if err != nil && err != io.EOF {
 			panic(err)
-		}
-		if n != size {
-			panic("msg too small")
 		}
 		b.SetBytes(int64(size))
 	}
 }
 
-func BenchmarkReadWriter1k(b *testing.B)  { benchmarkSockReadWriter(1024, b) }
-func BenchmarkReadWriter4k(b *testing.B)  { benchmarkSockReadWriter(4096, b) }
-func BenchmarkReadWriter16k(b *testing.B) { benchmarkSockReadWriter(16384, b) }
+func BenchmarkReadWriter1k(b *testing.B)  { benchmarkReadWriter(1024, b) }
+func BenchmarkReadWriter4k(b *testing.B)  { benchmarkReadWriter(4096, b) }
+func BenchmarkReadWriter16k(b *testing.B) { benchmarkReadWriter(16384, b) }

--- a/sock_test.go
+++ b/sock_test.go
@@ -3,7 +3,6 @@ package goczmq
 import (
 	"encoding/gob"
 	"fmt"
-	"io"
 	"testing"
 )
 
@@ -918,49 +917,6 @@ func benchmarkSockSendFrame(size int, b *testing.B) {
 func BenchmarkSockSendFrame1k(b *testing.B)  { benchmarkSockSendFrame(1024, b) }
 func BenchmarkSockSendFrame4k(b *testing.B)  { benchmarkSockSendFrame(4096, b) }
 func BenchmarkSockSendFrame16k(b *testing.B) { benchmarkSockSendFrame(16384, b) }
-
-func benchmarkSockReadWriter(size int, b *testing.B) {
-	pullSock := NewSock(Pull)
-	defer pullSock.Destroy()
-
-	_, err := pullSock.Bind(fmt.Sprintf("inproc://benchSockReadWriter%d", size))
-	if err != nil {
-		panic(err)
-	}
-
-	go func() {
-		pushSock := NewSock(Push)
-		defer pushSock.Destroy()
-		err := pushSock.Connect(fmt.Sprintf("inproc://benchSockReadWriter%d", size))
-		if err != nil {
-			panic(err)
-		}
-
-		payload := make([]byte, size)
-		for i := 0; i < b.N; i++ {
-			_, err = pushSock.Write(payload)
-			if err != nil {
-				panic(err)
-			}
-		}
-	}()
-
-	payload := make([]byte, size)
-	for i := 0; i < b.N; i++ {
-		n, err := pullSock.Read(payload)
-		if err != nil && err != io.EOF {
-			panic(err)
-		}
-		if n != size {
-			panic("msg too small")
-		}
-		b.SetBytes(int64(size))
-	}
-}
-
-func BenchmarkSockReadWriter1k(b *testing.B)  { benchmarkSockReadWriter(1024, b) }
-func BenchmarkSockReadWriter4k(b *testing.B)  { benchmarkSockReadWriter(4096, b) }
-func BenchmarkSockReadWriter16k(b *testing.B) { benchmarkSockReadWriter(16384, b) }
 
 func BenchmarkEncodeDecode(b *testing.B) {
 	pullSock := NewSock(Pull)


### PR DESCRIPTION
Having benchmarks for code we are deprecating isn't useful - as the first step towards deprecating sock.Read and sock.Write in favor of ReadWriter.Read and ReadWriter.Write, let's get rid of the benchmark tests for sock.Read / Sock.Write.