### PR TITLE
Problem: io.EOF semantics did not make sense

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -136,6 +136,9 @@ var (
 	// ErrMultiPartUnsupported is returned when a function that does
 	// not support multi-part messages encounters a multi-part message
 	ErrMultiPartUnsupported = errors.New("function does not support multi part messages")
+
+	// ErrTimeout is returned when a function that supports timeouts times out
+	ErrTimeout = errors.New("function timed out")
 )
 
 func getStringType(k int) string {

--- a/readwriter.go
+++ b/readwriter.go
@@ -31,7 +31,7 @@ func NewReadWriter(sock *Sock) (*ReadWriter, error) {
 
 // SetTimeout sets the timeout on Read in millisecond. If no new
 // data is received within the timeout period, Read will return
-// an io.EOF
+// an ErrTimeout
 func (r *ReadWriter) SetTimeout(ms int) {
 	r.timeoutMillis = ms
 }
@@ -47,7 +47,7 @@ func (r *ReadWriter) Read(p []byte) (int, error) {
 	if r.currentIndex == 0 {
 		s := r.poller.Wait(r.timeoutMillis)
 		if s == nil {
-			return totalRead, io.EOF
+			return totalRead, ErrTimeout
 		}
 
 		r.frame, flag, err = s.RecvFrame()
@@ -73,6 +73,7 @@ func (r *ReadWriter) Read(p []byte) (int, error) {
 		r.currentIndex = totalRead
 	} else {
 		r.currentIndex = 0
+		err = io.EOF
 	}
 
 	return totalRead, err

--- a/readwriter.go
+++ b/readwriter.go
@@ -21,7 +21,8 @@ type ReadWriter struct {
 // Sock.
 func NewReadWriter(sock *Sock) (*ReadWriter, error) {
 	rw := &ReadWriter{
-		sock: sock,
+		sock:          sock,
+		timeoutMillis: -1,
 	}
 
 	var err error

--- a/readwriter_test.go
+++ b/readwriter_test.go
@@ -34,8 +34,8 @@ func TestReadWriter(t *testing.T) {
 	b := make([]byte, 5)
 
 	n, err := pullReadWriter.Read(b)
-	if err != nil {
-		t.Error(err)
+	if want, got := io.EOF, err; want != got {
+		t.Errorf("want '%v', got '%v'", want, got)
 	}
 
 	if want, got := 5, n; want != got {
@@ -62,8 +62,8 @@ func TestReadWriter(t *testing.T) {
 	}
 
 	n, err = pullReadWriter.Read(b)
-	if err != nil {
-		t.Error(err)
+	if want, got := io.EOF, err; want != got {
+		t.Errorf("want '%v', got '%v'", want, got)
 	}
 
 	if want, got := 3, n; want != got {
@@ -76,8 +76,9 @@ func TestReadWriter(t *testing.T) {
 
 	pullReadWriter.SetTimeout(1)
 	n, err = pullReadWriter.Read(b)
-	if want, got := io.EOF, err; want != got {
-		t.Errorf("want '%s', got '%s'", want, got)
+
+	if want, got := ErrTimeout, err; want != got {
+		t.Errorf("want '%v', got '%v'", want, got)
 	}
 
 	if want, got := 0, n; want != got {
@@ -127,7 +128,7 @@ func TestReadWriterWithBufferSmallerThanFrame(t *testing.T) {
 	}
 
 	n, err = pullReadWriter.Read(b)
-	if err != nil {
+	if err != io.EOF {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
ZeroMQ does not expose transport disconnect information.  For instance, there is no way to detect when a client disconnects from a server at the transport level. In cases where knowledge of the number of clients is desired, this functionality is delegated to the application level.  Because of this, using io.EOF to denote when a "stream" has closed when reading from a socket is not possible.

ZeroMQ does have the concept of atomic messages, rather than a stream. In cases where we are reading a message where the message is larger than our read buffer, returning an io.EOF when the entirety of the message is read lets us use ReadWriter.Read and properly deal with messages.

So,. this PR changes ReadWriter.Read to return an io.EOF when reaching the end of a message, and changes a timeout on ReadWriter.Read to return an ErrTimeout rather than an io.EOF.

This also lays the groundwork for properly handling multi part messages ReadWriter.Read.