### PR TITLE
Problem: NewCertFromFile has no sanity check on filename.

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -9,6 +9,7 @@ import "C"
 
 import (
 	"fmt"
+	"os"
 	"unsafe"
 )
 
@@ -47,6 +48,11 @@ func NewCertFromKeys(public []byte, secret []byte) (*Cert, error) {
 
 // NewCertFromFile Load loads a Cert from files
 func NewCertFromFile(filename string) (*Cert, error) {
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return nil, ErrCertNotFound
+	}
+
 	cert := C.zcert_load(C.CString(filename))
 	return &Cert{
 		zcertT: cert,

--- a/cert_test.go
+++ b/cert_test.go
@@ -65,6 +65,13 @@ func TestCert(t *testing.T) {
 	os.Remove("./test_cert_secret")
 }
 
+func TestNewCertFromFile(t *testing.T) {
+	want, have := NewCertFromFile("./test_file_that_does_not_exist")
+	if have != ErrCertNotFound {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
 func ExampleCert() {
 	cert := NewCert()
 	defer cert.Destroy()

--- a/goczmq.go
+++ b/goczmq.go
@@ -139,6 +139,10 @@ var (
 
 	// ErrTimeout is returned when a function that supports timeouts times out
 	ErrTimeout = errors.New("function timed out")
+
+	// ErrCertNotFound is returned when NewCertFromFile tries to
+	// load a file that does not exist.
+	ErrCertNotFound = errors.New("file not found")
 )
 
 func getStringType(k int) string {


### PR DESCRIPTION
**Test output before fix**

```
dhanush@Indradhanushs-MacBook-Pro:~/golang/src/github.com/zeromq/goczmq$ go test -run NewCertFromFile
--- FAIL: TestNewCertFromFile (0.00s)
        cert_test.go:71: want &goczmq.Cert{zcertT:(*goczmq._Ctype_struct__zcert_t)(nil)}, have <nil>
FAIL
exit status 1
FAIL    github.com/zeromq/goczmq        0.015s
```
**Test output after fix**

```
dhanush@Indradhanushs-MacBook-Pro:~/golang/src/github.com/zeromq/goczmq$ go test -run NewCertFromFile
PASS
ok  	github.com/zeromq/goczmq	0.015s
```
