### PR TITLE
Problem: RecvFrame goes all bonkers if invoked after socket has been destroyed

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -126,6 +126,10 @@ var (
 	// ErrRecvFrame is returned if RecvFrame on a socket fails
 	ErrRecvFrame = errors.New("recv frame error")
 
+	// ErrRecvFrameAfterDestroy is returned if RecvFrame is called
+	// on a socket after it has been destroyed.
+	ErrRecvFrameAfterDestroy = errors.New("RecvFrame() is invalid on socket after Detroy() has been called.")
+
 	// ErrRecvMessage is returned if RecvMessage on a socket fails
 	ErrRecvMessage = errors.New("recv message error")
 

--- a/sock.go
+++ b/sock.go
@@ -260,6 +260,10 @@ func (s *Sock) SendFrame(data []byte, flags int) error {
 // as a byte array, along with a more flag and and error
 // (if there is an error)
 func (s *Sock) RecvFrame() ([]byte, int, error) {
+	if s.zsockT == nil {
+		return nil, -1, ErrRecvFrameAfterDestroy
+	}
+
 	frame := C.zframe_recv(unsafe.Pointer(s.zsockT))
 	if frame == nil {
 		return []byte{0}, 0, ErrRecvFrame


### PR DESCRIPTION
**Test output before fix:**

```
dhanush@Indradhanushs-MacBook-Pro:~/golang/src/github.com/zeromq/goczmq$ go test -run TestRecvFrameCalledAfterDestroy
Assertion failed: (source), function zframe_recv, file src/zframe.c, line 116.
SIGABRT: abort
PC=0x7fff8f55f866 m=0
signal arrived during cgo execution

goroutine 20 [syscall, locked to thread]:
runtime.cgocall(0x40029b0, 0xc8200235a8, 0x0)
	/usr/local/go/src/runtime/cgocall.go:120 +0x11b fp=0xc820023578 sp=0xc820023548
github.com/zeromq/goczmq._Cfunc_zframe_recv(0x0, 0x0)
	github.com/zeromq/goczmq/_test/_obj_test/_cgo_gotypes.go:543 +0x36 fp=0xc8200235a8 sp=0xc820023578
github.com/zeromq/goczmq.(*Sock).RecvFrame(0xc82006d6c0, 0x0, 0x0, 0x0, 0xc820070b01, 0x0, 0x0)
	/Users/dhanush/golang/src/github.com/zeromq/goczmq/sock.go:267 +0x66 fp=0xc820023608 sp=0xc8200235a8
github.com/zeromq/goczmq.TestRecvFrameCalledAfterDestroy(0xc82009c510)
	/Users/dhanush/golang/src/github.com/zeromq/goczmq/sock_test.go:863 +0x5aa fp=0xc820023778 sp=0xc820023608
testing.tRunner(0xc82009c510, 0x4312608)
	/usr/local/go/src/testing/testing.go:456 +0x98 fp=0xc8200237b0 sp=0xc820023778
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1 fp=0xc8200237b8 sp=0xc8200237b0
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:561 +0x86d

goroutine 1 [chan receive]:
testing.RunTests(0x426e758, 0x4311f00, 0x4c, 0x4c, 0x4012201)
	/usr/local/go/src/testing/testing.go:562 +0x8ad
testing.(*M).Run(0xc82004bef8, 0xf)
	/usr/local/go/src/testing/testing.go:494 +0x70
main.main()
	github.com/zeromq/goczmq/_test/_testmain.go:236 +0x116

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1

rax    0x0
rbx    0x7fff7814c310
rcx    0x7fff5fbff6d8
rdx    0x0
rdi    0x303
rsi    0x6
rbp    0x7fff5fbff700
rsp    0x7fff5fbff6d8
r8     0xfffff000
r9     0x74
r10    0x8000000
r11    0x206
r12    0x43f09e0
r13    0x43f09d4
r14    0x6
r15    0x43f09a0
rip    0x7fff8f55f866
rflags 0x206
cs     0x7
fs     0x0
gs     0x45f0000
exit status 2
FAIL	github.com/zeromq/goczmq	0.036s
```

**Test output after fix:**

```
dhanush@Indradhanushs-MacBook-Pro:~/golang/src/github.com/zeromq/goczmq$ go test -run TestRecvFrameCalledAfterDestroy
PASS
ok  	github.com/zeromq/goczmq	0.021s
```