### PR TITLE
Problem: Set_meta in cert producing compiler warning

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -3,7 +3,7 @@ package goczmq
 /*
 #include "czmq.h"
 
-void Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, value);}
+void Set_meta(zcert_t *self, const char *key, const char *value) {zcert_set_meta(self, key, "%s", value);}
 */
 import "C"
 


### PR DESCRIPTION
Solution: update Set_meta to call zcert_set_meta with a format string for value so that we don't get a warning.