### PR TITLE
Problem: we want to move forward on new socket types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,38 @@
 ## Introduction
 A golang interface to the [CZMQ v3](http://czmq.zeromq.org) API.
 
+## Update 2016-04-23 - gopkg.in
+Support for new thread safe socket types was recently added to CZMQ:
+
+New Socket Type| Old Socket Type
+---------------|----------------
+ZMQ_RADIO      | ZMQ_PUB
+ZMQ_DISH       | ZMQ_SUB
+ZMQ_CLIENT     | ZMQ_DEALER
+ZMQ_SERVER     | ZMQ_ROUTER
+ZMQ_SCATTER    | ZMQ_PUSH
+ZMQ_GATHER     | ZMQ_PULL
+
+Thread safe sockets are of immense value as far as Golang goes. Single frame messages
+also makes supporting io.Reader / io.Writer a much simpler proposition. However, 
+support for these sockets requires building against bleeding edge (as of this date)
+czmq / libzmq. There may be API breaking changes as a result as well. In order to 
+allow people to continue using GoCZMQ with the current stable releases of libzmq
+and czmq, we are moving to support [gopkg.in](http://labix.org/gopkg.in) urls.
+
+### Releases
+
+CZMQ Version | Package Url
+-------------|------------
+<= 3.02      | [`gopkg.in/zeromq/cmzq.v1`](https://gopkg.in/zeromq/czmq.v1)
+
+### Development Changes
+
+Work for GoCZMQ v2 will take place on a v2.0 branch. The C4.1 development process
+will still be used, other than the ammendent that PRs for 2.0 work should be
+opened from a fork against branch v2.0 rather than master. I am torn at this additional
+complication, but I believe it is the best way to move forward.
+
 ## Update 2015-06-02
 With the releases of zeromq 4.1 and czmq 3, we are declaring a stable release.
 What does "stable release" mean in the world of go getting projects off of git 
@@ -15,13 +47,13 @@ changes, and we may refactor internals in order to improve performance.
 ### Building From Source (Linux)
 
 ```
-wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.3.tar.gz
-wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.3.tar.gz.sig
+wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.10.tar.gz
+wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.10.tar.gz.sig
 wget https://download.libsodium.org/jedi.gpg.asc
 gpg --import jedi.gpg.asc
-gpg --verify libsodium-1.0.3.tar.gz.sig libsodium-1.0.3.tar.gz
-tar zxvf libsodium-1.0.3.tar.gz
-cd libsodium-1.0.3
+gpg --verify libsodium-1.0.10.tar.gz.sig libsodium-1.0.10.tar.gz
+tar zxvf libsodium-1.0.10.tar.gz
+cd libsodium-1.010.
 ./configure; make check
 sudo make install
 sudo ldconfig


### PR DESCRIPTION
Solution: move to using gopkg.in to provide stable release urls.