### PR TITLE
Problem: TestPushPullChanneler randomly fails (crash)

### DIFF
--- a/channeler.go
+++ b/channeler.go
@@ -1,5 +1,11 @@
 package goczmq
 
+/*
+#include "czmq.h"
+int Sock_init() {zsys_init();}
+*/
+import "C"
+
 import (
 	"fmt"
 	"math/rand"
@@ -170,6 +176,7 @@ func newChanneler(sockType int, endpoints, subscribe string) *Channeler {
 	sendChan := make(chan [][]byte)
 	recvChan := make(chan [][]byte)
 
+	C.Sock_init()
 	c := &Channeler{
 		id:          rand.Int63(),
 		subscribe:   subscribe,


### PR DESCRIPTION
New czmq sockets are created concurrently when creating a channel.
This may lead to a crash when initializing the CZMQ context the first time:
src/zsys.c:179: zsys_init: Assertion `!s_process_ctx' failed.

To solve this concurrency issue, initialize the CZMQ context earlier in the main thread