### PR TITLE
Sock.SendFrame leaks a 1 byte pointer when data length is zero

### DIFF
--- a/sock.go
+++ b/sock.go
@@ -261,7 +261,7 @@ func (s *Sock) Pollout() bool {
 func (s *Sock) SendFrame(data []byte, flags int) error {
 	var rc C.int
 	if len(data) == 0 {
-		rc = C.Sock_sendframe(unsafe.Pointer(s.zsockT), unsafe.Pointer(C.CString("")), C.size_t(len(data)), C.int(flags))
+		rc = C.Sock_sendframe(unsafe.Pointer(s.zsockT), nil, C.size_t(0), C.int(flags))
 	} else {
 		rc = C.Sock_sendframe(unsafe.Pointer(s.zsockT), unsafe.Pointer(&data[0]), C.size_t(len(data)), C.int(flags))
 	}


### PR DESCRIPTION
[`C.CString`](https://golang.org/src/cmd/cgo/out.go?#L1421) will create a 1 byte buffer when passed an empty string. `Sock.SendFrame` is currently doing this when `data` is of zero length. The buffer created is never freed, and thus will leak.