### PR TITLE
Problem: channeler had non void function with no return

### DIFF
--- a/channeler.go
+++ b/channeler.go
@@ -2,7 +2,7 @@ package goczmq
 
 /*
 #include "czmq.h"
-int Sock_init() {zsys_init();}
+void Sock_init() {zsys_init();}
 */
 import "C"
 


### PR DESCRIPTION
Solution: change return type of context init to void.