### PR TITLE
Problem: scatter-gather did not work on windows

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -16,7 +16,7 @@ package goczmq
 /*
 #cgo !windows pkg-config: libczmq libzmq libsodium
 #cgo windows LDFLAGS: -lws2_32 -liphlpapi -lrpcrt4 -lsodium -lzmq -lczmq
-#cgo windows CFLAGS: -Wno-pedantic-ms-format -DLIBCZMQ_EXPORTS -DZMQ_DEFINED_STDINT -DLIBCZMQ_EXPORTS
+#cgo windows CFLAGS: -Wno-pedantic-ms-format -DLIBCZMQ_EXPORTS -DZMQ_DEFINED_STDINT -DLIBCZMQ_EXPORTS -DZMQ_BUILD_DRAFT_API
 
 #include "czmq.h"
 #include <stdlib.h>


### PR DESCRIPTION
Solution: add -DZMQ_BUILD_DRAFT_API flag to cgo windows flags. See: https://github.com/zeromq/goczmq/issues/224