### PR TITLE
Problem: ubuntu has zmq packages without draft enabled

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -65,12 +65,6 @@ const (
 	// Stream is a ZMQ_STREAM socket type
 	Stream = int(C.ZMQ_STREAM)
 
-	// Scatter is a ZMQ_SCATTER socket type
-	Scatter = int(C.ZMQ_SCATTER)
-
-	// Gather is a ZMQ_GATHER socket type
-	Gather = int(C.ZMQ_GATHER)
-
 	// Pollin is the ZMQ_POLLIN constant
 	Pollin = int(C.ZMQ_POLLIN)
 

--- a/sock.go
+++ b/sock.go
@@ -246,20 +246,6 @@ func NewStream(endpoints string) (*Sock, error) {
 	return s, s.Attach(endpoints, false)
 }
 
-// NewGather creates a Gather socket and calls Attach.
-// The socket will Bind by default.
-func NewGather(endpoints string) (*Sock, error) {
-	s := NewSock(Gather)
-	return s, s.Attach(endpoints, true)
-}
-
-// NewScatter creates a Scatter socket and calls Attach.
-// The socket will Connect by default.
-func NewScatter(endpoints string) (*Sock, error) {
-	s := NewSock(Scatter)
-	return s, s.Attach(endpoints, false)
-}
-
 // Pollin returns true if there is a Pollin
 // event on the socket
 func (s *Sock) Pollin() bool {

--- a/sock_draft.go
+++ b/sock_draft.go
@@ -1,0 +1,30 @@
+// +build draft
+
+package goczmq
+
+/*
+#include "czmq.h"
+*/
+import "C"
+
+const (
+	// Scatter is a ZMQ_SCATTER socket type
+	Scatter = int(C.ZMQ_SCATTER)
+
+	// Gather is a ZMQ_GATHER socket type
+	Gather = int(C.ZMQ_GATHER)
+)
+
+// NewGather creates a Gather socket and calls Attach.
+// The socket will Bind by default.
+func NewGather(endpoints string) (*Sock, error) {
+	s := NewSock(Gather)
+	return s, s.Attach(endpoints, true)
+}
+
+// NewScatter creates a Scatter socket and calls Attach.
+// The socket will Connect by default.
+func NewScatter(endpoints string) (*Sock, error) {
+	s := NewSock(Scatter)
+	return s, s.Attach(endpoints, false)
+}

--- a/sock_draft_test.go
+++ b/sock_draft_test.go
@@ -1,0 +1,92 @@
+// +build draft
+
+package goczmq
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestScatterGather(t *testing.T) {
+	bogusScatter, err := NewScatter("bogus://bogus")
+	if err == nil {
+		t.Error(err)
+	}
+	defer bogusScatter.Destroy()
+
+	bogusGather, err := NewGather("bogus://bogus")
+	if err == nil {
+		t.Error(err)
+	}
+	defer bogusGather.Destroy()
+
+	scatter, err := NewScatter("inproc://scatter1,inproc://scatter2")
+	if err != nil {
+		t.Error(err)
+	}
+	defer scatter.Destroy()
+
+	gather, err := NewGather("inproc://scatter1,inproc://scatter2")
+	if err != nil {
+		t.Error(err)
+	}
+	defer gather.Destroy()
+
+	err = scatter.SendFrame([]byte("Hello World"), FlagNone)
+	if err != nil {
+		t.Error(err)
+	}
+
+	frame, _, err := gather.RecvFrame()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, have := "Hello World", string(frame); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
+func benchmarkScatterGather(size int, b *testing.B) {
+	gatherSock := NewSock(Gather)
+	defer gatherSock.Destroy()
+
+	_, err := gatherSock.Bind(fmt.Sprintf("inproc://benchScatterGather%#v", size))
+	if err != nil {
+		panic(err)
+	}
+
+	scatterSock := NewSock(Scatter)
+	defer scatterSock.Destroy()
+	err = scatterSock.Connect(fmt.Sprintf("inproc://benchScatterGather%#v", size))
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+
+		payload := make([]byte, size)
+		for i := 0; i < b.N; i++ {
+			err = scatterSock.SendFrame(payload, FlagNone)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		msg, _, err := gatherSock.RecvFrame()
+		if err != nil {
+			panic(err)
+		}
+		if len(msg) != size {
+			panic("msg too small")
+		}
+
+		b.SetBytes(int64(size))
+	}
+}
+
+func BenchmarkScatterGather1k(b *testing.B)  { benchmarkScatterGather(1024, b) }
+func BenchmarkScatterGather4k(b *testing.B)  { benchmarkScatterGather(4096, b) }
+func BenchmarkScatterGather16k(b *testing.B) { benchmarkScatterGather(16384, b) }

--- a/sock_test.go
+++ b/sock_test.go
@@ -285,46 +285,6 @@ func TestPushPull(t *testing.T) {
 	}
 }
 
-func TestScatterGather(t *testing.T) {
-	bogusScatter, err := NewScatter("bogus://bogus")
-	if err == nil {
-		t.Error(err)
-	}
-	defer bogusScatter.Destroy()
-
-	bogusGather, err := NewGather("bogus://bogus")
-	if err == nil {
-		t.Error(err)
-	}
-	defer bogusGather.Destroy()
-
-	scatter, err := NewScatter("inproc://scatter1,inproc://scatter2")
-	if err != nil {
-		t.Error(err)
-	}
-	defer scatter.Destroy()
-
-	gather, err := NewGather("inproc://scatter1,inproc://scatter2")
-	if err != nil {
-		t.Error(err)
-	}
-	defer gather.Destroy()
-
-	err = scatter.SendFrame([]byte("Hello World"), FlagNone)
-	if err != nil {
-		t.Error(err)
-	}
-
-	frame, _, err := gather.RecvFrame()
-	if err != nil {
-		t.Error(err)
-	}
-
-	if want, have := "Hello World", string(frame); want != have {
-		t.Errorf("want %#v, have %#v", want, have)
-	}
-}
-
 func TestRouterDealer(t *testing.T) {
 	bogusDealer, err := NewDealer("bogus://bogus")
 	if err == nil {
@@ -1037,47 +997,3 @@ func BenchmarkEncodeDecode(b *testing.B) {
 		}
 	}
 }
-
-func benchmarkScatterGather(size int, b *testing.B) {
-	gatherSock := NewSock(Gather)
-	defer gatherSock.Destroy()
-
-	_, err := gatherSock.Bind(fmt.Sprintf("inproc://benchScatterGather%#v", size))
-	if err != nil {
-		panic(err)
-	}
-
-	scatterSock := NewSock(Scatter)
-	defer scatterSock.Destroy()
-	err = scatterSock.Connect(fmt.Sprintf("inproc://benchScatterGather%#v", size))
-	if err != nil {
-		panic(err)
-	}
-
-	go func() {
-
-		payload := make([]byte, size)
-		for i := 0; i < b.N; i++ {
-			err = scatterSock.SendFrame(payload, FlagNone)
-			if err != nil {
-				panic(err)
-			}
-		}
-	}()
-
-	for i := 0; i < b.N; i++ {
-		msg, _, err := gatherSock.RecvFrame()
-		if err != nil {
-			panic(err)
-		}
-		if len(msg) != size {
-			panic("msg too small")
-		}
-
-		b.SetBytes(int64(size))
-	}
-}
-
-func BenchmarkScatterGather1k(b *testing.B)  { benchmarkScatterGather(1024, b) }
-func BenchmarkScatterGather4k(b *testing.B)  { benchmarkScatterGather(4096, b) }
-func BenchmarkScatterGather16k(b *testing.B) { benchmarkScatterGather(16384, b) }


### PR DESCRIPTION
Solution: move code  that depends on DRAFT features of zmq to separate files with draft build tag. These files will then not build by default. Users wishing to build against a czmq with draft enabled can pass "-tags draft" to go build.