### PR TITLE
Problem: beacon test can crash in some environments

### DIFF
--- a/beacon_test.go
+++ b/beacon_test.go
@@ -44,8 +44,6 @@ func TestBeacon(t *testing.T) {
 	speaker.Publish("HI", 100)
 
 	msg := listener.Recv(500)
-	t.Logf("Address: %s", string(msg[0]))
-	t.Logf("Beacon: %s", string(msg[1]))
 
 	listener.Destroy()
 	speaker.Destroy()


### PR DESCRIPTION
Solution: remove test log output