### PR TITLE
Problem: beacon test doesnt work on travis

### DIFF
--- a/beacon_test.go
+++ b/beacon_test.go
@@ -44,8 +44,10 @@ func TestBeacon(t *testing.T) {
 	speaker.Publish("HI", 100)
 
 	msg := listener.Recv(500)
-	t.Logf("Address: %s", string(msg[0]))
-	t.Logf("Beacon: %s", string(msg[1]))
+	if len(msg) == 2 {
+		t.Logf("Address: %s", string(msg[0]))
+		t.Logf("Beacon: %s", string(msg[1]))
+	}
 
 	listener.Destroy()
 	speaker.Destroy()


### PR DESCRIPTION
Solution: check if returned message is valid length before calling test log command