### PR TITLE
Problem: CZMQ 4.2 is required, not just 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ by passing `--enable-drafts` to configure. Support for these draft classes are b
 to goczmq. To build these features against a CZMQ that has been compiled with `--enable-drafts`,
 use `go build -tags draft`.
 
-### For CMZQ = 4.0
+### For CMZQ = 4.2
 ```
 go get gopkg.in/zeromq/goczmq.v4
 ```
+**Note**: [CZMQ 4.2](https://github.com/zeromq/czmq/releases) is has not been released yet.
+
 ### For CZMQ Before 4.0
 ```
 go get gopkg.in/zeromq/goczmq.v1


### PR DESCRIPTION
# Problem

Documentation states that the code will work with CZMQ 4.x+ However, this does not seem to be the case.

## Versions Pulled
```json
{                                                               
    "checksumSHA1": "nnlv7YDAEQZv0XMm4CMgMaJJnAA=",         
     "path": "gopkg.in/zeromq/goczmq.v4",                    
     "revision": "98ab09146269d98bc3e427046f5fc222c4134e0b", 
     "revisionTime": "2017-10-08T14:05:00Z"                  
}  
```

```json
 {                                                               
     "checksumSHA1": "7Y/ABorbMzLNU3sNoK3/nPtgcVU=",         
     "path": "github.com/zeromq/goczmq",                     
     "revision": "a3998524f7fcd7fab479e485fa2ae3b02bcf6cac", 
     "revisionTime": "2017-11-11T20:18:50Z"                  
}
```

## Local Libraries

```
$ rpm -qa | grep zmq
cppzmq-devel-4.1.6-2.fc26.x86_64
czmq-devel-4.0.2-5.fc27.x86_64
czmq-4.0.2-5.fc27.x86_64
$ rpm -qa | grep zeromq
zeromq-devel-4.1.6-2.fc26.x86_64
zeromq-4.1.6-2.fc26.x86_64
```

## Compilers
```
$ rpm -qa | grep golang
golang-1.9.2-1.fc27.x86_64
golang-src-1.9.2-1.fc27.noarch
golang-bin-1.9.2-1.fc27.x86_64
$ rpm -qa | grep gcc
gcc-7.2.1-2.fc27.x86_64
libgcc-7.2.1-2.fc27.x86_64
```


## Build Errors

```
/usr/lib/golang/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_connect_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:77: undefined reference to `zsock_connect_timeout'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_heartbeat_ivl':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:288: undefined reference to `zsock_heartbeat_ivl'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_heartbeat_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:306: undefined reference to `zsock_heartbeat_timeout'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_heartbeat_ttl':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:324: undefined reference to `zsock_heartbeat_ttl'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_invert_matching':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:377: undefined reference to `zsock_invert_matching'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_multicast_maxtpdu':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:520: undefined reference to `zsock_multicast_maxtpdu'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_connect_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:787: undefined reference to `zsock_set_connect_timeout'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_heartbeat_ivl':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:936: undefined reference to `zsock_set_heartbeat_ivl'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_heartbeat_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:950: undefined reference to `zsock_set_heartbeat_timeout'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_heartbeat_ttl':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:964: undefined reference to `zsock_set_heartbeat_ttl'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_invert_matching':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1005: undefined reference to `zsock_set_invert_matching'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_multicast_maxtpdu':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1089: undefined reference to `zsock_set_multicast_maxtpdu'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_stream_notify':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1366: undefined reference to `zsock_set_stream_notify'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_tcp_maxrt':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1462: undefined reference to `zsock_set_tcp_maxrt'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_use_fd':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1503: undefined reference to `zsock_set_use_fd'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_vmci_buffer_max_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1517: undefined reference to `zsock_set_vmci_buffer_max_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_vmci_buffer_min_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1531: undefined reference to `zsock_set_vmci_buffer_min_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_vmci_buffer_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1545: undefined reference to `zsock_set_vmci_buffer_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_vmci_connect_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1559: undefined reference to `zsock_set_vmci_connect_timeout'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_xpub_manual':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1573: undefined reference to `zsock_set_xpub_manual'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_xpub_verboser':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1615: undefined reference to `zsock_set_xpub_verboser'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_set_xpub_welcome_msg':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1628: undefined reference to `zsock_set_xpub_welcome_msg'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_tcp_maxrt':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1817: undefined reference to `zsock_tcp_maxrt'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_thread_safe':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1835: undefined reference to `zsock_thread_safe'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_use_fd':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1889: undefined reference to `zsock_use_fd'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_vmci_buffer_max_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1907: undefined reference to `zsock_vmci_buffer_max_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_vmci_buffer_min_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1925: undefined reference to `zsock_vmci_buffer_min_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_vmci_buffer_size':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1943: undefined reference to `zsock_vmci_buffer_size'
/tmp/go-link-960616506/000000.o: In function `_cgo_d0d31912427f_Cfunc_zsock_vmci_connect_timeout':
github.com/zeromq/goczmq/_obj/cgo-gcc-prolog:1961: undefined reference to `zsock_vmci_connect_timeout'
collect2: error: ld returned 1 exit status
```

# Solution

Update documentation to note a requirement on the unreleased CZMQ 4.2.x

## Updates
Manually create 4.2.0 builds of CZMQ and installed locally.

```
$ rpm -qa | grep czmq
czmq-4.2.0-1.fc27.x86_64
czmq-devel-4.2.0-1.fc27.x86_64
```

No more errors when building.