### PR TITLE
Allow passing SockOptions to Channeler constructors

### DIFF
--- a/channeler.go
+++ b/channeler.go
@@ -206,7 +206,7 @@ ExitChanneler:
 
 // newChanneler accepts arguments from the socket type based
 // constructors and creates a new Channeler instance
-func newChanneler(sockType int, endpoints string, subscribe ...string) *Channeler {
+func newChanneler(sockType int, endpoints string, subscribe []string) *Channeler {
 	commandChan := make(chan string)
 	sendChan := make(chan [][]byte)
 	recvChan := make(chan [][]byte)
@@ -237,7 +237,7 @@ func newChanneler(sockType int, endpoints string, subscribe ...string) *Channele
 // NewPubChanneler creats a new Channeler wrapping
 // a Pub socket.  The socket will bind by default.
 func NewPubChanneler(endpoints string) *Channeler {
-	return newChanneler(Pub, endpoints, "")
+	return newChanneler(Pub, endpoints, nil)
 }
 
 // NewSubChanneler creates a new Channeler wrapping
@@ -245,65 +245,65 @@ func NewPubChanneler(endpoints string) *Channeler {
 // it accepts a comma delimited list of topics.
 // The socket will connect by default.
 func NewSubChanneler(endpoints string, subscribe ...string) *Channeler {
-	return newChanneler(Sub, endpoints, subscribe...)
+	return newChanneler(Sub, endpoints, subscribe)
 }
 
 // NewRepChanneler creates a new Channeler wrapping
 // a Rep socket. The socket will bind by default.
 func NewRepChanneler(endpoints string) *Channeler {
-	return newChanneler(Rep, endpoints, "")
+	return newChanneler(Rep, endpoints, nil)
 }
 
 // NewReqChanneler creates a new Channeler wrapping
 // a Req socket. The socket will connect by default.
 func NewReqChanneler(endpoints string) *Channeler {
-	return newChanneler(Req, endpoints, "")
+	return newChanneler(Req, endpoints, nil)
 }
 
 // NewPullChanneler creates a new Channeler wrapping
 // a Pull socket. The socket will bind by default.
 func NewPullChanneler(endpoints string) *Channeler {
-	return newChanneler(Pull, endpoints, "")
+	return newChanneler(Pull, endpoints, nil)
 }
 
 // NewPushChanneler creates a new Channeler wrapping
 // a Push socket. The socket will connect by default.
 func NewPushChanneler(endpoints string) *Channeler {
-	return newChanneler(Push, endpoints, "")
+	return newChanneler(Push, endpoints, nil)
 }
 
 // NewRouterChanneler creates a new Channeler wrapping
 // a Router socket. The socket will Bind by default.
 func NewRouterChanneler(endpoints string) *Channeler {
-	return newChanneler(Router, endpoints, "")
+	return newChanneler(Router, endpoints, nil)
 }
 
 // NewDealerChanneler creates a new Channeler wrapping
 // a Dealer socket. The socket will connect by default.
 func NewDealerChanneler(endpoints string) *Channeler {
-	return newChanneler(Dealer, endpoints, "")
+	return newChanneler(Dealer, endpoints, nil)
 }
 
 // NewXPubChanneler creates a new Channeler wrapping
 // an XPub socket. The socket will Bind by default.
 func NewXPubChanneler(endpoints string) *Channeler {
-	return newChanneler(XPub, endpoints, "")
+	return newChanneler(XPub, endpoints, nil)
 }
 
 // NewXSubChanneler creates a new Channeler wrapping
 // a XSub socket. The socket will connect by default.
 func NewXSubChanneler(endpoints string) *Channeler {
-	return newChanneler(XSub, endpoints, "")
+	return newChanneler(XSub, endpoints, nil)
 }
 
 // NewPairChanneler creates a new Channeler wrapping
 // a Pair socket. The socket will connect by default.
 func NewPairChanneler(endpoints string) *Channeler {
-	return newChanneler(Pair, endpoints, "")
+	return newChanneler(Pair, endpoints, nil)
 }
 
 // NewStreamChanneler creates a new Channeler wrapping
 // a Pair socket. The socket will connect by default.
 func NewStreamChanneler(endpoints string) *Channeler {
-	return newChanneler(Stream, endpoints, "")
+	return newChanneler(Stream, endpoints, nil)
 }

--- a/channeler.go
+++ b/channeler.go
@@ -47,7 +47,7 @@ func (c *Channeler) Unsubscribe(topic string) {
 
 // actor is a routine that handles communication with
 // the zeromq socket.
-func (c *Channeler) actor(recvChan chan<- [][]byte) {
+func (c *Channeler) actor(recvChan chan<- [][]byte, options []SockOption) {
 	pipe, err := NewPair(fmt.Sprintf(">%s", c.commandAddr))
 	if err != nil {
 		panic(err)
@@ -61,7 +61,7 @@ func (c *Channeler) actor(recvChan chan<- [][]byte) {
 	}
 	defer pull.Destroy()
 
-	sock := NewSock(c.sockType)
+	sock := NewSock(c.sockType, options...)
 	defer sock.Destroy()
 	switch c.sockType {
 	case Pub, Rep, Pull, Router, XPub:
@@ -206,7 +206,7 @@ ExitChanneler:
 
 // newChanneler accepts arguments from the socket type based
 // constructors and creates a new Channeler instance
-func newChanneler(sockType int, endpoints string, subscribe []string) *Channeler {
+func newChanneler(sockType int, endpoints string, subscribe []string, options []SockOption) *Channeler {
 	commandChan := make(chan string)
 	sendChan := make(chan [][]byte)
 	recvChan := make(chan [][]byte)
@@ -229,15 +229,15 @@ func newChanneler(sockType int, endpoints string, subscribe []string) *Channeler
 	}
 
 	go c.channeler(commandChan, sendChan)
-	go c.actor(recvChan)
+	go c.actor(recvChan, options)
 
 	return c
 }
 
 // NewPubChanneler creats a new Channeler wrapping
 // a Pub socket.  The socket will bind by default.
-func NewPubChanneler(endpoints string) *Channeler {
-	return newChanneler(Pub, endpoints, nil)
+func NewPubChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Pub, endpoints, nil, options)
 }
 
 // NewSubChanneler creates a new Channeler wrapping
@@ -245,65 +245,65 @@ func NewPubChanneler(endpoints string) *Channeler {
 // it accepts a comma delimited list of topics.
 // The socket will connect by default.
 func NewSubChanneler(endpoints string, subscribe ...string) *Channeler {
-	return newChanneler(Sub, endpoints, subscribe)
+	return newChanneler(Sub, endpoints, subscribe, nil)
 }
 
 // NewRepChanneler creates a new Channeler wrapping
 // a Rep socket. The socket will bind by default.
-func NewRepChanneler(endpoints string) *Channeler {
-	return newChanneler(Rep, endpoints, nil)
+func NewRepChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Rep, endpoints, nil, options)
 }
 
 // NewReqChanneler creates a new Channeler wrapping
 // a Req socket. The socket will connect by default.
-func NewReqChanneler(endpoints string) *Channeler {
-	return newChanneler(Req, endpoints, nil)
+func NewReqChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Req, endpoints, nil, options)
 }
 
 // NewPullChanneler creates a new Channeler wrapping
 // a Pull socket. The socket will bind by default.
-func NewPullChanneler(endpoints string) *Channeler {
-	return newChanneler(Pull, endpoints, nil)
+func NewPullChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Pull, endpoints, nil, options)
 }
 
 // NewPushChanneler creates a new Channeler wrapping
 // a Push socket. The socket will connect by default.
-func NewPushChanneler(endpoints string) *Channeler {
-	return newChanneler(Push, endpoints, nil)
+func NewPushChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Push, endpoints, nil, options)
 }
 
 // NewRouterChanneler creates a new Channeler wrapping
 // a Router socket. The socket will Bind by default.
-func NewRouterChanneler(endpoints string) *Channeler {
-	return newChanneler(Router, endpoints, nil)
+func NewRouterChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Router, endpoints, nil, options)
 }
 
 // NewDealerChanneler creates a new Channeler wrapping
 // a Dealer socket. The socket will connect by default.
-func NewDealerChanneler(endpoints string) *Channeler {
-	return newChanneler(Dealer, endpoints, nil)
+func NewDealerChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Dealer, endpoints, nil, options)
 }
 
 // NewXPubChanneler creates a new Channeler wrapping
 // an XPub socket. The socket will Bind by default.
-func NewXPubChanneler(endpoints string) *Channeler {
-	return newChanneler(XPub, endpoints, nil)
+func NewXPubChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(XPub, endpoints, nil, options)
 }
 
 // NewXSubChanneler creates a new Channeler wrapping
 // a XSub socket. The socket will connect by default.
-func NewXSubChanneler(endpoints string) *Channeler {
-	return newChanneler(XSub, endpoints, nil)
+func NewXSubChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(XSub, endpoints, nil, options)
 }
 
 // NewPairChanneler creates a new Channeler wrapping
 // a Pair socket. The socket will connect by default.
-func NewPairChanneler(endpoints string) *Channeler {
-	return newChanneler(Pair, endpoints, nil)
+func NewPairChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Pair, endpoints, nil, options)
 }
 
 // NewStreamChanneler creates a new Channeler wrapping
 // a Pair socket. The socket will connect by default.
-func NewStreamChanneler(endpoints string) *Channeler {
-	return newChanneler(Stream, endpoints, nil)
+func NewStreamChanneler(endpoints string, options ...SockOption) *Channeler {
+	return newChanneler(Stream, endpoints, nil, options)
 }

--- a/channeler.go
+++ b/channeler.go
@@ -242,10 +242,25 @@ func NewPubChanneler(endpoints string, options ...SockOption) *Channeler {
 
 // NewSubChanneler creates a new Channeler wrapping
 // a Sub socket. Along with an endpoint list
-// it accepts a comma delimited list of topics.
-// The socket will connect by default.
-func NewSubChanneler(endpoints string, subscribe ...string) *Channeler {
-	return newChanneler(Sub, endpoints, subscribe, nil)
+// it accepts a list of topics and/or socket options
+// (discriminated by type). The socket will connect
+// by default.
+func NewSubChanneler(endpoints string, varargs ...interface{}) *Channeler {
+	subscribe := []string{}
+	options := []SockOption{}
+
+	for _, arg := range varargs {
+		switch x := arg.(type) {
+		case string:
+			subscribe = append(subscribe, x)
+		case SockOption:
+			options = append(options, x)
+		default:
+			panic(fmt.Sprintf("Don't know how to handle a %T argument to NewSubChanneler", arg))
+		}
+	}
+
+	return newChanneler(Sub, endpoints, subscribe, options)
 }
 
 // NewRepChanneler creates a new Channeler wrapping


### PR DESCRIPTION
This is meant to address #135, among other things (there are other options you might want to set on a Channeler's socket). I'm not sure if it's really a complete solution (there are some options that it makes sense to set post-creation) but it's better than nothing.

It adds a `...SockOption` parameter to most of the Channeler constructors, except for `NewSubChanneler` which already had a `...string` parameter for the subscriptions list — this becomes a `...interface{}` which can contain subscriptions *or* `SockOption`s, identified by their type. This isn't entirely pretty, but it avoids breaking the API.

I would have liked to write some tests for these changes, but since the socket is a local variable to the actor method, it's fairly difficult to detect whether an option has been set, even from a test in the same package. I considered using a test-custom `SockOption` with side-effects, but couldn't figure out how to do that without creating races, so in the end I just gave up. Refactoring the code to make it testable would have made for a larger PR, which I didn't want.