### PR TITLE
Fix #242: Unable to recover from panics when creating new Channeler

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -59,7 +59,10 @@ func TestAuthIPAllow(t *testing.T) {
 	}
 	defer poller.Destroy()
 
-	s := poller.Wait(200)
+	s, err := poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := server, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -162,7 +165,10 @@ func TestAuthPlain(t *testing.T) {
 	}
 	defer poller.Destroy()
 
-	s := poller.Wait(200)
+	s, err := poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := server, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -195,7 +201,10 @@ func TestAuthPlain(t *testing.T) {
 		t.Error(err)
 	}
 
-	s = poller.Wait(200)
+	s, err = poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if s != nil {
 		t.Errorf("want %#v, have %#v", nil, s)
 	}
@@ -274,7 +283,10 @@ func TestAuthCurveAllowAny(t *testing.T) {
 	}
 	defer poller.Destroy()
 
-	s := poller.Wait(2000)
+	s, err := poller.Wait(2000)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := server, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -302,7 +314,10 @@ func TestAuthCurveAllowAny(t *testing.T) {
 		t.Error(err)
 	}
 
-	s = poller.Wait(200)
+	s, err = poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if s != nil {
 		t.Errorf("want %#v, have %#v", nil, s)
 	}
@@ -381,7 +396,10 @@ func TestAuthCurveAllowCertificate(t *testing.T) {
 	}
 	defer poller.Destroy()
 
-	s := poller.Wait(200)
+	s, err := poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := server, s; want != have {
 		t.Errorf("want '%#v', have '%#v'", want, have)
 	}
@@ -400,7 +418,10 @@ func TestAuthCurveAllowCertificate(t *testing.T) {
 		t.Error(err)
 	}
 
-	s = poller.Wait(200)
+	s, err = poller.Wait(200)
+	if err != nil {
+		t.Error(err)
+	}
 	if s != nil {
 		t.Errorf("want '%#v', have '%#v", nil, s)
 	}

--- a/goczmq.go
+++ b/goczmq.go
@@ -108,6 +108,9 @@ var (
 	// ErrSockAttach is returned when an attach call to a socket fails
 	ErrSockAttach = errors.New("error attaching zsock")
 
+	// ErrSockAttachEmptyEndpoints is returned when the endpoints value is empty
+	ErrSockAttachEmptyEndpoints = errors.New("Endpoints cannot be empty")
+
 	// ErrInvalidSockType is returned when a function is called
 	// against a socket type that is not applicable for that socket type
 	ErrInvalidSockType = errors.New("invalid socket type")

--- a/poller_test.go
+++ b/poller_test.go
@@ -34,7 +34,10 @@ func TestPollerNewNoSocks(t *testing.T) {
 		t.Error(err)
 	}
 
-	s := poller.Wait(0)
+	s, err := poller.Wait(0)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := pullSock1, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -111,7 +114,10 @@ func TestPoller(t *testing.T) {
 		t.Error(err)
 	}
 
-	s := poller.Wait(0)
+	s, err := poller.Wait(0)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := pullSock1, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -136,7 +142,10 @@ func TestPoller(t *testing.T) {
 		t.Error(err)
 	}
 
-	s = poller.Wait(0)
+	s, err = poller.Wait(0)
+	if err != nil {
+		t.Error(err)
+	}
 	if want, have := pullSock2, s; want != have {
 		t.Errorf("want %#v, have %#v", want, have)
 	}
@@ -167,21 +176,16 @@ func TestPollerAfterDestroy(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	poller.Wait(0)
+	_, err = poller.Wait(0)
+	if err != nil {
+		t.Error(err)
+	}
 
-	// https://github.com/zeromq/goczmq/issues/145
-	// Verify expected panic behavior if Wait() is invoked after a Destroy()
 	poller.Destroy()
-	defer func() {
-		if r := recover(); r != nil {
-			if r != ErrWaitAfterDestroy {
-				t.Errorf("Expected a specific panic, `%s`,\n  but have `%s`", ErrWaitAfterDestroy.Error(), r)
-			}
-		} else {
-			t.Errorf("Expected panic, but did not panic.")
-		}
-	}()
-	poller.Wait(0)
+	_, err = poller.Wait(0)
+	if err != ErrWaitAfterDestroy {
+		t.Errorf("want %#v, have %#v", ErrWaitAfterDestroy, err)
+	}
 }
 
 func ExamplePoller() {
@@ -208,7 +212,7 @@ func ExamplePoller() {
 	}
 
 	// Poller.Wait(millis) returns first socket that has a waiting message
-	_ = poller.Wait(1)
+	poller.Wait(1)
 }
 
 func benchmarkPollerSendFrame(size int, b *testing.B) {
@@ -244,7 +248,10 @@ func benchmarkPollerSendFrame(size int, b *testing.B) {
 	defer poller.Destroy()
 
 	for i := 0; i < b.N; i++ {
-		s := poller.Wait(-1)
+		s, err := poller.Wait(-1)
+		if err != nil {
+			b.Error(err)
+		}
 		msg, _, err := s.RecvFrame()
 		if err != nil {
 			panic(err)

--- a/readwriter.go
+++ b/readwriter.go
@@ -46,7 +46,10 @@ func (r *ReadWriter) Read(p []byte) (int, error) {
 	var err error
 
 	if r.currentIndex == 0 {
-		s := r.poller.Wait(r.timeoutMillis)
+		s, err := r.poller.Wait(r.timeoutMillis)
+		if err != nil {
+			return totalRead, err
+		}
 		if s == nil {
 			return totalRead, ErrTimeout
 		}

--- a/sock.go
+++ b/sock.go
@@ -18,6 +18,7 @@ int Sock_sendframe(zsock_t *sock, const void *data, size_t size, int flags) {
 import "C"
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -35,7 +36,7 @@ type Sock struct {
 
 func init() {
 	if err := os.Setenv("ZSYS_SIGHANDLER", "false"); err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "Failed to set environment variable ZSYS_SIGHANDLER: %s\n", err.Error())
 	}
 }
 
@@ -158,6 +159,10 @@ func (s *Sock) Unbind(endpoint string) error {
 // does not start with '@' or '>', the serverish argument determines whether
 // it is used to bind (serverish = true) or connect (serverish = false)
 func (s *Sock) Attach(endpoints string, serverish bool) error {
+	if endpoints == "" {
+		return ErrSockAttachEmptyEndpoints
+	}
+
 	cEndpoints := C.CString(endpoints)
 	defer C.free(unsafe.Pointer(cEndpoints))
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -1,0 +1,17 @@
+package goczmq
+
+import (
+	"fmt"
+	"testing"
+)
+
+func assertEqual(t *testing.T, expected interface{}, value interface{}, message ...string) {
+	if expected == value {
+		return
+	}
+	msg := fmt.Sprintf("'%v' != '%v'. Expected '%v' but got '%v'", expected, value, expected, value)
+	for _, m := range message {
+		msg += fmt.Sprintf(". %s", m)
+	}
+	t.Fatal(msg)
+}


### PR DESCRIPTION
Currently, calls to panic() are used to communiate errors. Doing this
from goroutines makes it impossible to recover from the panics, which
effectively forces the program to exit.

Fix this by replacing panic() calls with a new error channel to
communicate errors back to caller.

Resolves #242. Comments?