### PR TITLE
Problem: old sock option api was deprecated

### DIFF
--- a/sock_option.go
+++ b/sock_option.go
@@ -31,11 +31,6 @@ import (
 	"unsafe"
 )
 
-// SetHeartbeatIvl sets the heartbeat_ivl option for the socket
-func (s *Sock) SetHeartbeatIvl(val int) {
-	C.zsock_set_heartbeat_ivl(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetHeartbeatIvl sets the heartbeat_ivl option for the socket
 func SockSetHeartbeatIvl(v int) SockOption {
 	return func(s *Sock) {
@@ -44,20 +39,9 @@ func SockSetHeartbeatIvl(v int) SockOption {
 }
 
 // HeartbeatIvl returns the current value of the socket's heartbeat_ivl option
-func (s *Sock) HeartbeatIvl() int {
-	val := C.zsock_heartbeat_ivl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// HeartbeatIvl returns the current value of the socket's heartbeat_ivl option
 func HeartbeatIvl(s *Sock) int {
 	val := C.zsock_heartbeat_ivl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetHeartbeatTtl sets the heartbeat_ttl option for the socket
-func (s *Sock) SetHeartbeatTtl(val int) {
-	C.zsock_set_heartbeat_ttl(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetHeartbeatTtl sets the heartbeat_ttl option for the socket
@@ -68,20 +52,9 @@ func SockSetHeartbeatTtl(v int) SockOption {
 }
 
 // HeartbeatTtl returns the current value of the socket's heartbeat_ttl option
-func (s *Sock) HeartbeatTtl() int {
-	val := C.zsock_heartbeat_ttl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// HeartbeatTtl returns the current value of the socket's heartbeat_ttl option
 func HeartbeatTtl(s *Sock) int {
 	val := C.zsock_heartbeat_ttl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetHeartbeatTimeout sets the heartbeat_timeout option for the socket
-func (s *Sock) SetHeartbeatTimeout(val int) {
-	C.zsock_set_heartbeat_timeout(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetHeartbeatTimeout sets the heartbeat_timeout option for the socket
@@ -92,20 +65,9 @@ func SockSetHeartbeatTimeout(v int) SockOption {
 }
 
 // HeartbeatTimeout returns the current value of the socket's heartbeat_timeout option
-func (s *Sock) HeartbeatTimeout() int {
-	val := C.zsock_heartbeat_timeout(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// HeartbeatTimeout returns the current value of the socket's heartbeat_timeout option
 func HeartbeatTimeout(s *Sock) int {
 	val := C.zsock_heartbeat_timeout(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetUseFd sets the use_fd option for the socket
-func (s *Sock) SetUseFd(val int) {
-	C.zsock_set_use_fd(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetUseFd sets the use_fd option for the socket
@@ -116,20 +78,9 @@ func SockSetUseFd(v int) SockOption {
 }
 
 // UseFd returns the current value of the socket's use_fd option
-func (s *Sock) UseFd() int {
-	val := C.zsock_use_fd(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// UseFd returns the current value of the socket's use_fd option
 func UseFd(s *Sock) int {
 	val := C.zsock_use_fd(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetXPubManual sets the xpub_manual option for the socket
-func (s *Sock) SetXPubManual(val int) {
-	C.zsock_set_xpub_manual(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetXPubManual sets the xpub_manual option for the socket
@@ -137,14 +88,6 @@ func SockSetXPubManual(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_xpub_manual(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetXPubWelcomeMsg sets the xpub_welcome_msg option for the socket
-func (s *Sock) SetXPubWelcomeMsg(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_xpub_welcome_msg(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetXPubWelcomeMsg sets the xpub_welcome_msg option for the socket
@@ -156,21 +99,11 @@ func SockSetXPubWelcomeMsg(v string) SockOption {
 	}
 }
 
-// SetStreamNotify sets the stream_notify option for the socket
-func (s *Sock) SetStreamNotify(val int) {
-	C.zsock_set_stream_notify(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetStreamNotify sets the stream_notify option for the socket
 func SockSetStreamNotify(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_stream_notify(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetInvertMatching sets the invert_matching option for the socket
-func (s *Sock) SetInvertMatching(val int) {
-	C.zsock_set_invert_matching(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetInvertMatching sets the invert_matching option for the socket
@@ -181,20 +114,9 @@ func SockSetInvertMatching(v int) SockOption {
 }
 
 // InvertMatching returns the current value of the socket's invert_matching option
-func (s *Sock) InvertMatching() int {
-	val := C.zsock_invert_matching(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// InvertMatching returns the current value of the socket's invert_matching option
 func InvertMatching(s *Sock) int {
 	val := C.zsock_invert_matching(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetXPubVerboser sets the xpub_verboser option for the socket
-func (s *Sock) SetXPubVerboser(val int) {
-	C.zsock_set_xpub_verboser(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetXPubVerboser sets the xpub_verboser option for the socket
@@ -202,11 +124,6 @@ func SockSetXPubVerboser(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_xpub_verboser(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetConnectTimeout sets the connect_timeout option for the socket
-func (s *Sock) SetConnectTimeout(val int) {
-	C.zsock_set_connect_timeout(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetConnectTimeout sets the connect_timeout option for the socket
@@ -217,20 +134,9 @@ func SockSetConnectTimeout(v int) SockOption {
 }
 
 // ConnectTimeout returns the current value of the socket's connect_timeout option
-func (s *Sock) ConnectTimeout() int {
-	val := C.zsock_connect_timeout(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// ConnectTimeout returns the current value of the socket's connect_timeout option
 func ConnectTimeout(s *Sock) int {
 	val := C.zsock_connect_timeout(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetTcpMaxrt sets the tcp_maxrt option for the socket
-func (s *Sock) SetTcpMaxrt(val int) {
-	C.zsock_set_tcp_maxrt(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTcpMaxrt sets the tcp_maxrt option for the socket
@@ -241,20 +147,8 @@ func SockSetTcpMaxrt(v int) SockOption {
 }
 
 // TcpMaxrt returns the current value of the socket's tcp_maxrt option
-func (s *Sock) TcpMaxrt() int {
-	val := C.zsock_tcp_maxrt(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// TcpMaxrt returns the current value of the socket's tcp_maxrt option
 func TcpMaxrt(s *Sock) int {
 	val := C.zsock_tcp_maxrt(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// ThreadSafe returns the current value of the socket's thread_safe option
-func (s *Sock) ThreadSafe() int {
-	val := C.zsock_thread_safe(unsafe.Pointer(s.zsockT))
 	return int(val)
 }
 
@@ -262,11 +156,6 @@ func (s *Sock) ThreadSafe() int {
 func ThreadSafe(s *Sock) int {
 	val := C.zsock_thread_safe(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetMulticastMaxtpdu sets the multicast_maxtpdu option for the socket
-func (s *Sock) SetMulticastMaxtpdu(val int) {
-	C.zsock_set_multicast_maxtpdu(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetMulticastMaxtpdu sets the multicast_maxtpdu option for the socket
@@ -277,20 +166,9 @@ func SockSetMulticastMaxtpdu(v int) SockOption {
 }
 
 // MulticastMaxtpdu returns the current value of the socket's multicast_maxtpdu option
-func (s *Sock) MulticastMaxtpdu() int {
-	val := C.zsock_multicast_maxtpdu(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// MulticastMaxtpdu returns the current value of the socket's multicast_maxtpdu option
 func MulticastMaxtpdu(s *Sock) int {
 	val := C.zsock_multicast_maxtpdu(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetVmciBufferSize sets the vmci_buffer_size option for the socket
-func (s *Sock) SetVmciBufferSize(val int) {
-	C.zsock_set_vmci_buffer_size(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetVmciBufferSize sets the vmci_buffer_size option for the socket
@@ -301,20 +179,9 @@ func SockSetVmciBufferSize(v int) SockOption {
 }
 
 // VmciBufferSize returns the current value of the socket's vmci_buffer_size option
-func (s *Sock) VmciBufferSize() int {
-	val := C.zsock_vmci_buffer_size(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// VmciBufferSize returns the current value of the socket's vmci_buffer_size option
 func VmciBufferSize(s *Sock) int {
 	val := C.zsock_vmci_buffer_size(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetVmciBufferMinSize sets the vmci_buffer_min_size option for the socket
-func (s *Sock) SetVmciBufferMinSize(val int) {
-	C.zsock_set_vmci_buffer_min_size(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetVmciBufferMinSize sets the vmci_buffer_min_size option for the socket
@@ -325,20 +192,9 @@ func SockSetVmciBufferMinSize(v int) SockOption {
 }
 
 // VmciBufferMinSize returns the current value of the socket's vmci_buffer_min_size option
-func (s *Sock) VmciBufferMinSize() int {
-	val := C.zsock_vmci_buffer_min_size(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// VmciBufferMinSize returns the current value of the socket's vmci_buffer_min_size option
 func VmciBufferMinSize(s *Sock) int {
 	val := C.zsock_vmci_buffer_min_size(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetVmciBufferMaxSize sets the vmci_buffer_max_size option for the socket
-func (s *Sock) SetVmciBufferMaxSize(val int) {
-	C.zsock_set_vmci_buffer_max_size(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetVmciBufferMaxSize sets the vmci_buffer_max_size option for the socket
@@ -349,20 +205,9 @@ func SockSetVmciBufferMaxSize(v int) SockOption {
 }
 
 // VmciBufferMaxSize returns the current value of the socket's vmci_buffer_max_size option
-func (s *Sock) VmciBufferMaxSize() int {
-	val := C.zsock_vmci_buffer_max_size(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// VmciBufferMaxSize returns the current value of the socket's vmci_buffer_max_size option
 func VmciBufferMaxSize(s *Sock) int {
 	val := C.zsock_vmci_buffer_max_size(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetVmciConnectTimeout sets the vmci_connect_timeout option for the socket
-func (s *Sock) SetVmciConnectTimeout(val int) {
-	C.zsock_set_vmci_connect_timeout(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetVmciConnectTimeout sets the vmci_connect_timeout option for the socket
@@ -373,23 +218,9 @@ func SockSetVmciConnectTimeout(v int) SockOption {
 }
 
 // VmciConnectTimeout returns the current value of the socket's vmci_connect_timeout option
-func (s *Sock) VmciConnectTimeout() int {
-	val := C.zsock_vmci_connect_timeout(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// VmciConnectTimeout returns the current value of the socket's vmci_connect_timeout option
 func VmciConnectTimeout(s *Sock) int {
 	val := C.zsock_vmci_connect_timeout(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetConnectRid sets the connect_rid option for the socket
-func (s *Sock) SetConnectRid(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_connect_rid(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetConnectRid sets the connect_rid option for the socket
@@ -401,11 +232,6 @@ func SockSetConnectRid(v string) SockOption {
 	}
 }
 
-// SetHandshakeIvl sets the handshake_ivl option for the socket
-func (s *Sock) SetHandshakeIvl(val int) {
-	C.zsock_set_handshake_ivl(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetHandshakeIvl sets the handshake_ivl option for the socket
 func SockSetHandshakeIvl(v int) SockOption {
 	return func(s *Sock) {
@@ -414,23 +240,9 @@ func SockSetHandshakeIvl(v int) SockOption {
 }
 
 // HandshakeIvl returns the current value of the socket's handshake_ivl option
-func (s *Sock) HandshakeIvl() int {
-	val := C.zsock_handshake_ivl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// HandshakeIvl returns the current value of the socket's handshake_ivl option
 func HandshakeIvl(s *Sock) int {
 	val := C.zsock_handshake_ivl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetSocksProxy sets the socks_proxy option for the socket
-func (s *Sock) SetSocksProxy(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_socks_proxy(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetSocksProxy sets the socks_proxy option for the socket
@@ -443,20 +255,9 @@ func SockSetSocksProxy(v string) SockOption {
 }
 
 // SocksProxy returns the current value of the socket's socks_proxy option
-func (s *Sock) SocksProxy() string {
-	val := C.zsock_socks_proxy(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// SocksProxy returns the current value of the socket's socks_proxy option
 func SocksProxy(s *Sock) string {
 	val := C.zsock_socks_proxy(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetXPubNodrop sets the xpub_nodrop option for the socket
-func (s *Sock) SetXPubNodrop(val int) {
-	C.zsock_set_xpub_nodrop(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetXPubNodrop sets the xpub_nodrop option for the socket
@@ -464,11 +265,6 @@ func SockSetXPubNodrop(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_xpub_nodrop(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetTos sets the tos option for the socket
-func (s *Sock) SetTos(val int) {
-	C.zsock_set_tos(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTos sets the tos option for the socket
@@ -479,20 +275,9 @@ func SockSetTos(v int) SockOption {
 }
 
 // Tos returns the current value of the socket's tos option
-func (s *Sock) Tos() int {
-	val := C.zsock_tos(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Tos returns the current value of the socket's tos option
 func Tos(s *Sock) int {
 	val := C.zsock_tos(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRouterHandover sets the router_handover option for the socket
-func (s *Sock) SetRouterHandover(val int) {
-	C.zsock_set_router_handover(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRouterHandover sets the router_handover option for the socket
@@ -502,21 +287,11 @@ func SockSetRouterHandover(v int) SockOption {
 	}
 }
 
-// SetRouterMandatory sets the router_mandatory option for the socket
-func (s *Sock) SetRouterMandatory(val int) {
-	C.zsock_set_router_mandatory(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetRouterMandatory sets the router_mandatory option for the socket
 func SockSetRouterMandatory(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_router_mandatory(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetProbeRouter sets the probe_router option for the socket
-func (s *Sock) SetProbeRouter(val int) {
-	C.zsock_set_probe_router(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetProbeRouter sets the probe_router option for the socket
@@ -526,21 +301,11 @@ func SockSetProbeRouter(v int) SockOption {
 	}
 }
 
-// SetReqRelaxed sets the req_relaxed option for the socket
-func (s *Sock) SetReqRelaxed(val int) {
-	C.zsock_set_req_relaxed(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetReqRelaxed sets the req_relaxed option for the socket
 func SockSetReqRelaxed(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_req_relaxed(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetReqCorrelate sets the req_correlate option for the socket
-func (s *Sock) SetReqCorrelate(val int) {
-	C.zsock_set_req_correlate(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetReqCorrelate sets the req_correlate option for the socket
@@ -550,24 +315,11 @@ func SockSetReqCorrelate(v int) SockOption {
 	}
 }
 
-// SetConflate sets the conflate option for the socket
-func (s *Sock) SetConflate(val int) {
-	C.zsock_set_conflate(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSetConflate sets the conflate option for the socket
 func SockSetConflate(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_conflate(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetZapDomain sets the zap_domain option for the socket
-func (s *Sock) SetZapDomain(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_zap_domain(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetZapDomain sets the zap_domain option for the socket
@@ -580,32 +332,15 @@ func SockSetZapDomain(v string) SockOption {
 }
 
 // ZapDomain returns the current value of the socket's zap_domain option
-func (s *Sock) ZapDomain() string {
-	val := C.zsock_zap_domain(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// ZapDomain returns the current value of the socket's zap_domain option
 func ZapDomain(s *Sock) string {
 	val := C.zsock_zap_domain(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
 }
 
 // Mechanism returns the current value of the socket's mechanism option
-func (s *Sock) Mechanism() int {
-	val := C.zsock_mechanism(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Mechanism returns the current value of the socket's mechanism option
 func Mechanism(s *Sock) int {
 	val := C.zsock_mechanism(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetPlainServer sets the plain_server option for the socket
-func (s *Sock) SetPlainServer(val int) {
-	C.zsock_set_plain_server(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetPlainServer sets the plain_server option for the socket
@@ -616,23 +351,9 @@ func SockSetPlainServer(v int) SockOption {
 }
 
 // PlainServer returns the current value of the socket's plain_server option
-func (s *Sock) PlainServer() int {
-	val := C.zsock_plain_server(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// PlainServer returns the current value of the socket's plain_server option
 func PlainServer(s *Sock) int {
 	val := C.zsock_plain_server(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetPlainUsername sets the plain_username option for the socket
-func (s *Sock) SetPlainUsername(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_plain_username(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetPlainUsername sets the plain_username option for the socket
@@ -645,23 +366,9 @@ func SockSetPlainUsername(v string) SockOption {
 }
 
 // PlainUsername returns the current value of the socket's plain_username option
-func (s *Sock) PlainUsername() string {
-	val := C.zsock_plain_username(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// PlainUsername returns the current value of the socket's plain_username option
 func PlainUsername(s *Sock) string {
 	val := C.zsock_plain_username(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetPlainPassword sets the plain_password option for the socket
-func (s *Sock) SetPlainPassword(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_plain_password(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetPlainPassword sets the plain_password option for the socket
@@ -674,20 +381,9 @@ func SockSetPlainPassword(v string) SockOption {
 }
 
 // PlainPassword returns the current value of the socket's plain_password option
-func (s *Sock) PlainPassword() string {
-	val := C.zsock_plain_password(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// PlainPassword returns the current value of the socket's plain_password option
 func PlainPassword(s *Sock) string {
 	val := C.zsock_plain_password(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetCurveServer sets the curve_server option for the socket
-func (s *Sock) SetCurveServer(val int) {
-	C.zsock_set_curve_server(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetCurveServer sets the curve_server option for the socket
@@ -698,23 +394,9 @@ func SockSetCurveServer(v int) SockOption {
 }
 
 // CurveServer returns the current value of the socket's curve_server option
-func (s *Sock) CurveServer() int {
-	val := C.zsock_curve_server(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// CurveServer returns the current value of the socket's curve_server option
 func CurveServer(s *Sock) int {
 	val := C.zsock_curve_server(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetCurvePublickey sets the curve_publickey option for the socket
-func (s *Sock) SetCurvePublickey(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_curve_publickey(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetCurvePublickey sets the curve_publickey option for the socket
@@ -727,23 +409,9 @@ func SockSetCurvePublickey(v string) SockOption {
 }
 
 // CurvePublickey returns the current value of the socket's curve_publickey option
-func (s *Sock) CurvePublickey() string {
-	val := C.zsock_curve_publickey(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// CurvePublickey returns the current value of the socket's curve_publickey option
 func CurvePublickey(s *Sock) string {
 	val := C.zsock_curve_publickey(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetCurveSecretkey sets the curve_secretkey option for the socket
-func (s *Sock) SetCurveSecretkey(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_curve_secretkey(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetCurveSecretkey sets the curve_secretkey option for the socket
@@ -756,23 +424,9 @@ func SockSetCurveSecretkey(v string) SockOption {
 }
 
 // CurveSecretkey returns the current value of the socket's curve_secretkey option
-func (s *Sock) CurveSecretkey() string {
-	val := C.zsock_curve_secretkey(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// CurveSecretkey returns the current value of the socket's curve_secretkey option
 func CurveSecretkey(s *Sock) string {
 	val := C.zsock_curve_secretkey(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetCurveServerkey sets the curve_serverkey option for the socket
-func (s *Sock) SetCurveServerkey(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_curve_serverkey(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetCurveServerkey sets the curve_serverkey option for the socket
@@ -785,20 +439,9 @@ func SockSetCurveServerkey(v string) SockOption {
 }
 
 // CurveServerkey returns the current value of the socket's curve_serverkey option
-func (s *Sock) CurveServerkey() string {
-	val := C.zsock_curve_serverkey(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// CurveServerkey returns the current value of the socket's curve_serverkey option
 func CurveServerkey(s *Sock) string {
 	val := C.zsock_curve_serverkey(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetGssapiServer sets the gssapi_server option for the socket
-func (s *Sock) SetGssapiServer(val int) {
-	C.zsock_set_gssapi_server(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetGssapiServer sets the gssapi_server option for the socket
@@ -809,20 +452,9 @@ func SockSetGssapiServer(v int) SockOption {
 }
 
 // GssapiServer returns the current value of the socket's gssapi_server option
-func (s *Sock) GssapiServer() int {
-	val := C.zsock_gssapi_server(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// GssapiServer returns the current value of the socket's gssapi_server option
 func GssapiServer(s *Sock) int {
 	val := C.zsock_gssapi_server(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetGssapiPlaintext sets the gssapi_plaintext option for the socket
-func (s *Sock) SetGssapiPlaintext(val int) {
-	C.zsock_set_gssapi_plaintext(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetGssapiPlaintext sets the gssapi_plaintext option for the socket
@@ -833,23 +465,9 @@ func SockSetGssapiPlaintext(v int) SockOption {
 }
 
 // GssapiPlaintext returns the current value of the socket's gssapi_plaintext option
-func (s *Sock) GssapiPlaintext() int {
-	val := C.zsock_gssapi_plaintext(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// GssapiPlaintext returns the current value of the socket's gssapi_plaintext option
 func GssapiPlaintext(s *Sock) int {
 	val := C.zsock_gssapi_plaintext(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetGssapiPrincipal sets the gssapi_principal option for the socket
-func (s *Sock) SetGssapiPrincipal(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_gssapi_principal(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetGssapiPrincipal sets the gssapi_principal option for the socket
@@ -862,23 +480,9 @@ func SockSetGssapiPrincipal(v string) SockOption {
 }
 
 // GssapiPrincipal returns the current value of the socket's gssapi_principal option
-func (s *Sock) GssapiPrincipal() string {
-	val := C.zsock_gssapi_principal(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// GssapiPrincipal returns the current value of the socket's gssapi_principal option
 func GssapiPrincipal(s *Sock) string {
 	val := C.zsock_gssapi_principal(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetGssapiServicePrincipal sets the gssapi_service_principal option for the socket
-func (s *Sock) SetGssapiServicePrincipal(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_gssapi_service_principal(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetGssapiServicePrincipal sets the gssapi_service_principal option for the socket
@@ -891,20 +495,9 @@ func SockSetGssapiServicePrincipal(v string) SockOption {
 }
 
 // GssapiServicePrincipal returns the current value of the socket's gssapi_service_principal option
-func (s *Sock) GssapiServicePrincipal() string {
-	val := C.zsock_gssapi_service_principal(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// GssapiServicePrincipal returns the current value of the socket's gssapi_service_principal option
 func GssapiServicePrincipal(s *Sock) string {
 	val := C.zsock_gssapi_service_principal(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetIpv6 sets the ipv6 option for the socket
-func (s *Sock) SetIpv6(val int) {
-	C.zsock_set_ipv6(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetIpv6 sets the ipv6 option for the socket
@@ -915,20 +508,9 @@ func SockSetIpv6(v int) SockOption {
 }
 
 // Ipv6 returns the current value of the socket's ipv6 option
-func (s *Sock) Ipv6() int {
-	val := C.zsock_ipv6(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Ipv6 returns the current value of the socket's ipv6 option
 func Ipv6(s *Sock) int {
 	val := C.zsock_ipv6(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetImmediate sets the immediate option for the socket
-func (s *Sock) SetImmediate(val int) {
-	C.zsock_set_immediate(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetImmediate sets the immediate option for the socket
@@ -939,20 +521,9 @@ func SockSetImmediate(v int) SockOption {
 }
 
 // Immediate returns the current value of the socket's immediate option
-func (s *Sock) Immediate() int {
-	val := C.zsock_immediate(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Immediate returns the current value of the socket's immediate option
 func Immediate(s *Sock) int {
 	val := C.zsock_immediate(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRouterRaw sets the router_raw option for the socket
-func (s *Sock) SetRouterRaw(val int) {
-	C.zsock_set_router_raw(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRouterRaw sets the router_raw option for the socket
@@ -960,11 +531,6 @@ func SockSetRouterRaw(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_router_raw(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetIpv4only sets the ipv4only option for the socket
-func (s *Sock) SetIpv4only(val int) {
-	C.zsock_set_ipv4only(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetIpv4only sets the ipv4only option for the socket
@@ -975,20 +541,9 @@ func SockSetIpv4only(v int) SockOption {
 }
 
 // Ipv4only returns the current value of the socket's ipv4only option
-func (s *Sock) Ipv4only() int {
-	val := C.zsock_ipv4only(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Ipv4only returns the current value of the socket's ipv4only option
 func Ipv4only(s *Sock) int {
 	val := C.zsock_ipv4only(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetDelayAttachOnConnect sets the delay_attach_on_connect option for the socket
-func (s *Sock) SetDelayAttachOnConnect(val int) {
-	C.zsock_set_delay_attach_on_connect(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetDelayAttachOnConnect sets the delay_attach_on_connect option for the socket
@@ -999,20 +554,9 @@ func SockSetDelayAttachOnConnect(v int) SockOption {
 }
 
 // Type returns the current value of the socket's type option
-func (s *Sock) Type() int {
-	val := C.zsock_type(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Type returns the current value of the socket's type option
 func Type(s *Sock) int {
 	val := C.zsock_type(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetSndhwm sets the sndhwm option for the socket
-func (s *Sock) SetSndhwm(val int) {
-	C.zsock_set_sndhwm(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetSndhwm sets the sndhwm option for the socket
@@ -1023,20 +567,9 @@ func SockSetSndhwm(v int) SockOption {
 }
 
 // Sndhwm returns the current value of the socket's sndhwm option
-func (s *Sock) Sndhwm() int {
-	val := C.zsock_sndhwm(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Sndhwm returns the current value of the socket's sndhwm option
 func Sndhwm(s *Sock) int {
 	val := C.zsock_sndhwm(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRcvhwm sets the rcvhwm option for the socket
-func (s *Sock) SetRcvhwm(val int) {
-	C.zsock_set_rcvhwm(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRcvhwm sets the rcvhwm option for the socket
@@ -1047,20 +580,9 @@ func SockSetRcvhwm(v int) SockOption {
 }
 
 // Rcvhwm returns the current value of the socket's rcvhwm option
-func (s *Sock) Rcvhwm() int {
-	val := C.zsock_rcvhwm(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Rcvhwm returns the current value of the socket's rcvhwm option
 func Rcvhwm(s *Sock) int {
 	val := C.zsock_rcvhwm(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetAffinity sets the affinity option for the socket
-func (s *Sock) SetAffinity(val int) {
-	C.zsock_set_affinity(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetAffinity sets the affinity option for the socket
@@ -1071,23 +593,9 @@ func SockSetAffinity(v int) SockOption {
 }
 
 // Affinity returns the current value of the socket's affinity option
-func (s *Sock) Affinity() int {
-	val := C.zsock_affinity(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Affinity returns the current value of the socket's affinity option
 func Affinity(s *Sock) int {
 	val := C.zsock_affinity(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetSubscribe sets the subscribe option for the socket
-func (s *Sock) SetSubscribe(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_subscribe(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetSubscribe sets the subscribe option for the socket
@@ -1099,14 +607,6 @@ func SockSetSubscribe(v string) SockOption {
 	}
 }
 
-// SetUnsubscribe sets the unsubscribe option for the socket
-func (s *Sock) SetUnsubscribe(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_unsubscribe(unsafe.Pointer(s.zsockT), cVal)
-}
-
 // SockSetUnsubscribe sets the unsubscribe option for the socket
 func SockSetUnsubscribe(v string) SockOption {
 	return func(s *Sock) {
@@ -1114,14 +614,6 @@ func SockSetUnsubscribe(v string) SockOption {
 		defer C.free(unsafe.Pointer(cV))
 		C.zsock_set_unsubscribe(unsafe.Pointer(s.zsockT), cV)
 	}
-}
-
-// SetIdentity sets the identity option for the socket
-func (s *Sock) SetIdentity(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_identity(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetIdentity sets the identity option for the socket
@@ -1134,20 +626,9 @@ func SockSetIdentity(v string) SockOption {
 }
 
 // Identity returns the current value of the socket's identity option
-func (s *Sock) Identity() string {
-	val := C.zsock_identity(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// Identity returns the current value of the socket's identity option
 func Identity(s *Sock) string {
 	val := C.zsock_identity(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
-}
-
-// SetRate sets the rate option for the socket
-func (s *Sock) SetRate(val int) {
-	C.zsock_set_rate(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRate sets the rate option for the socket
@@ -1158,20 +639,9 @@ func SockSetRate(v int) SockOption {
 }
 
 // Rate returns the current value of the socket's rate option
-func (s *Sock) Rate() int {
-	val := C.zsock_rate(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Rate returns the current value of the socket's rate option
 func Rate(s *Sock) int {
 	val := C.zsock_rate(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRecoveryIvl sets the recovery_ivl option for the socket
-func (s *Sock) SetRecoveryIvl(val int) {
-	C.zsock_set_recovery_ivl(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRecoveryIvl sets the recovery_ivl option for the socket
@@ -1182,20 +652,9 @@ func SockSetRecoveryIvl(v int) SockOption {
 }
 
 // RecoveryIvl returns the current value of the socket's recovery_ivl option
-func (s *Sock) RecoveryIvl() int {
-	val := C.zsock_recovery_ivl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// RecoveryIvl returns the current value of the socket's recovery_ivl option
 func RecoveryIvl(s *Sock) int {
 	val := C.zsock_recovery_ivl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetSndbuf sets the sndbuf option for the socket
-func (s *Sock) SetSndbuf(val int) {
-	C.zsock_set_sndbuf(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetSndbuf sets the sndbuf option for the socket
@@ -1206,20 +665,9 @@ func SockSetSndbuf(v int) SockOption {
 }
 
 // Sndbuf returns the current value of the socket's sndbuf option
-func (s *Sock) Sndbuf() int {
-	val := C.zsock_sndbuf(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Sndbuf returns the current value of the socket's sndbuf option
 func Sndbuf(s *Sock) int {
 	val := C.zsock_sndbuf(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRcvbuf sets the rcvbuf option for the socket
-func (s *Sock) SetRcvbuf(val int) {
-	C.zsock_set_rcvbuf(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRcvbuf sets the rcvbuf option for the socket
@@ -1230,20 +678,9 @@ func SockSetRcvbuf(v int) SockOption {
 }
 
 // Rcvbuf returns the current value of the socket's rcvbuf option
-func (s *Sock) Rcvbuf() int {
-	val := C.zsock_rcvbuf(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Rcvbuf returns the current value of the socket's rcvbuf option
 func Rcvbuf(s *Sock) int {
 	val := C.zsock_rcvbuf(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetLinger sets the linger option for the socket
-func (s *Sock) SetLinger(val int) {
-	C.zsock_set_linger(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetLinger sets the linger option for the socket
@@ -1254,20 +691,9 @@ func SockSetLinger(v int) SockOption {
 }
 
 // Linger returns the current value of the socket's linger option
-func (s *Sock) Linger() int {
-	val := C.zsock_linger(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Linger returns the current value of the socket's linger option
 func Linger(s *Sock) int {
 	val := C.zsock_linger(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetReconnectIvl sets the reconnect_ivl option for the socket
-func (s *Sock) SetReconnectIvl(val int) {
-	C.zsock_set_reconnect_ivl(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetReconnectIvl sets the reconnect_ivl option for the socket
@@ -1278,20 +704,9 @@ func SockSetReconnectIvl(v int) SockOption {
 }
 
 // ReconnectIvl returns the current value of the socket's reconnect_ivl option
-func (s *Sock) ReconnectIvl() int {
-	val := C.zsock_reconnect_ivl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// ReconnectIvl returns the current value of the socket's reconnect_ivl option
 func ReconnectIvl(s *Sock) int {
 	val := C.zsock_reconnect_ivl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetReconnectIvlMax sets the reconnect_ivl_max option for the socket
-func (s *Sock) SetReconnectIvlMax(val int) {
-	C.zsock_set_reconnect_ivl_max(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetReconnectIvlMax sets the reconnect_ivl_max option for the socket
@@ -1302,20 +717,9 @@ func SockSetReconnectIvlMax(v int) SockOption {
 }
 
 // ReconnectIvlMax returns the current value of the socket's reconnect_ivl_max option
-func (s *Sock) ReconnectIvlMax() int {
-	val := C.zsock_reconnect_ivl_max(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// ReconnectIvlMax returns the current value of the socket's reconnect_ivl_max option
 func ReconnectIvlMax(s *Sock) int {
 	val := C.zsock_reconnect_ivl_max(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetBacklog sets the backlog option for the socket
-func (s *Sock) SetBacklog(val int) {
-	C.zsock_set_backlog(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetBacklog sets the backlog option for the socket
@@ -1326,20 +730,9 @@ func SockSetBacklog(v int) SockOption {
 }
 
 // Backlog returns the current value of the socket's backlog option
-func (s *Sock) Backlog() int {
-	val := C.zsock_backlog(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Backlog returns the current value of the socket's backlog option
 func Backlog(s *Sock) int {
 	val := C.zsock_backlog(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetMaxmsgsize sets the maxmsgsize option for the socket
-func (s *Sock) SetMaxmsgsize(val int) {
-	C.zsock_set_maxmsgsize(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetMaxmsgsize sets the maxmsgsize option for the socket
@@ -1350,20 +743,9 @@ func SockSetMaxmsgsize(v int) SockOption {
 }
 
 // Maxmsgsize returns the current value of the socket's maxmsgsize option
-func (s *Sock) Maxmsgsize() int {
-	val := C.zsock_maxmsgsize(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Maxmsgsize returns the current value of the socket's maxmsgsize option
 func Maxmsgsize(s *Sock) int {
 	val := C.zsock_maxmsgsize(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetMulticastHops sets the multicast_hops option for the socket
-func (s *Sock) SetMulticastHops(val int) {
-	C.zsock_set_multicast_hops(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetMulticastHops sets the multicast_hops option for the socket
@@ -1374,20 +756,9 @@ func SockSetMulticastHops(v int) SockOption {
 }
 
 // MulticastHops returns the current value of the socket's multicast_hops option
-func (s *Sock) MulticastHops() int {
-	val := C.zsock_multicast_hops(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// MulticastHops returns the current value of the socket's multicast_hops option
 func MulticastHops(s *Sock) int {
 	val := C.zsock_multicast_hops(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetRcvtimeo sets the rcvtimeo option for the socket
-func (s *Sock) SetRcvtimeo(val int) {
-	C.zsock_set_rcvtimeo(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetRcvtimeo sets the rcvtimeo option for the socket
@@ -1398,20 +769,9 @@ func SockSetRcvtimeo(v int) SockOption {
 }
 
 // Rcvtimeo returns the current value of the socket's rcvtimeo option
-func (s *Sock) Rcvtimeo() int {
-	val := C.zsock_rcvtimeo(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Rcvtimeo returns the current value of the socket's rcvtimeo option
 func Rcvtimeo(s *Sock) int {
 	val := C.zsock_rcvtimeo(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetSndtimeo sets the sndtimeo option for the socket
-func (s *Sock) SetSndtimeo(val int) {
-	C.zsock_set_sndtimeo(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetSndtimeo sets the sndtimeo option for the socket
@@ -1422,20 +782,9 @@ func SockSetSndtimeo(v int) SockOption {
 }
 
 // Sndtimeo returns the current value of the socket's sndtimeo option
-func (s *Sock) Sndtimeo() int {
-	val := C.zsock_sndtimeo(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Sndtimeo returns the current value of the socket's sndtimeo option
 func Sndtimeo(s *Sock) int {
 	val := C.zsock_sndtimeo(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetXPubVerbose sets the xpub_verbose option for the socket
-func (s *Sock) SetXPubVerbose(val int) {
-	C.zsock_set_xpub_verbose(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetXPubVerbose sets the xpub_verbose option for the socket
@@ -1443,11 +792,6 @@ func SockSetXPubVerbose(v int) SockOption {
 	return func(s *Sock) {
 		C.zsock_set_xpub_verbose(unsafe.Pointer(s.zsockT), C.int(v))
 	}
-}
-
-// SetTcpKeepalive sets the tcp_keepalive option for the socket
-func (s *Sock) SetTcpKeepalive(val int) {
-	C.zsock_set_tcp_keepalive(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTcpKeepalive sets the tcp_keepalive option for the socket
@@ -1458,20 +802,9 @@ func SockSetTcpKeepalive(v int) SockOption {
 }
 
 // TcpKeepalive returns the current value of the socket's tcp_keepalive option
-func (s *Sock) TcpKeepalive() int {
-	val := C.zsock_tcp_keepalive(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// TcpKeepalive returns the current value of the socket's tcp_keepalive option
 func TcpKeepalive(s *Sock) int {
 	val := C.zsock_tcp_keepalive(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetTcpKeepaliveIdle sets the tcp_keepalive_idle option for the socket
-func (s *Sock) SetTcpKeepaliveIdle(val int) {
-	C.zsock_set_tcp_keepalive_idle(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTcpKeepaliveIdle sets the tcp_keepalive_idle option for the socket
@@ -1482,20 +815,9 @@ func SockSetTcpKeepaliveIdle(v int) SockOption {
 }
 
 // TcpKeepaliveIdle returns the current value of the socket's tcp_keepalive_idle option
-func (s *Sock) TcpKeepaliveIdle() int {
-	val := C.zsock_tcp_keepalive_idle(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// TcpKeepaliveIdle returns the current value of the socket's tcp_keepalive_idle option
 func TcpKeepaliveIdle(s *Sock) int {
 	val := C.zsock_tcp_keepalive_idle(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetTcpKeepaliveCnt sets the tcp_keepalive_cnt option for the socket
-func (s *Sock) SetTcpKeepaliveCnt(val int) {
-	C.zsock_set_tcp_keepalive_cnt(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTcpKeepaliveCnt sets the tcp_keepalive_cnt option for the socket
@@ -1506,20 +828,9 @@ func SockSetTcpKeepaliveCnt(v int) SockOption {
 }
 
 // TcpKeepaliveCnt returns the current value of the socket's tcp_keepalive_cnt option
-func (s *Sock) TcpKeepaliveCnt() int {
-	val := C.zsock_tcp_keepalive_cnt(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// TcpKeepaliveCnt returns the current value of the socket's tcp_keepalive_cnt option
 func TcpKeepaliveCnt(s *Sock) int {
 	val := C.zsock_tcp_keepalive_cnt(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetTcpKeepaliveIntvl sets the tcp_keepalive_intvl option for the socket
-func (s *Sock) SetTcpKeepaliveIntvl(val int) {
-	C.zsock_set_tcp_keepalive_intvl(unsafe.Pointer(s.zsockT), C.int(val))
 }
 
 // SockSetTcpKeepaliveIntvl sets the tcp_keepalive_intvl option for the socket
@@ -1530,23 +841,9 @@ func SockSetTcpKeepaliveIntvl(v int) SockOption {
 }
 
 // TcpKeepaliveIntvl returns the current value of the socket's tcp_keepalive_intvl option
-func (s *Sock) TcpKeepaliveIntvl() int {
-	val := C.zsock_tcp_keepalive_intvl(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// TcpKeepaliveIntvl returns the current value of the socket's tcp_keepalive_intvl option
 func TcpKeepaliveIntvl(s *Sock) int {
 	val := C.zsock_tcp_keepalive_intvl(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// SetTcpAcceptFilter sets the tcp_accept_filter option for the socket
-func (s *Sock) SetTcpAcceptFilter(val string) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_tcp_accept_filter(unsafe.Pointer(s.zsockT), cVal)
 }
 
 // SockSetTcpAcceptFilter sets the tcp_accept_filter option for the socket
@@ -1559,32 +856,14 @@ func SockSetTcpAcceptFilter(v string) SockOption {
 }
 
 // TcpAcceptFilter returns the current value of the socket's tcp_accept_filter option
-func (s *Sock) TcpAcceptFilter() string {
-	val := C.zsock_tcp_accept_filter(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
-// TcpAcceptFilter returns the current value of the socket's tcp_accept_filter option
 func TcpAcceptFilter(s *Sock) string {
 	val := C.zsock_tcp_accept_filter(unsafe.Pointer(s.zsockT))
 	return C.GoString(val)
 }
 
 // Rcvmore returns the current value of the socket's rcvmore option
-func (s *Sock) Rcvmore() int {
-	val := C.zsock_rcvmore(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Rcvmore returns the current value of the socket's rcvmore option
 func Rcvmore(s *Sock) int {
 	val := C.zsock_rcvmore(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Fd returns the current value of the socket's fd option
-func (s *Sock) Fd() int {
-	val := C.zsock_fd(unsafe.Pointer(s.zsockT))
 	return int(val)
 }
 
@@ -1595,21 +874,9 @@ func Fd(s *Sock) int {
 }
 
 // Events returns the current value of the socket's events option
-func (s *Sock) Events() int {
-	val := C.zsock_events(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// Events returns the current value of the socket's events option
 func Events(s *Sock) int {
 	val := C.zsock_events(unsafe.Pointer(s.zsockT))
 	return int(val)
-}
-
-// LastEndpoint returns the current value of the socket's last_endpoint option
-func (s *Sock) LastEndpoint() string {
-	val := C.zsock_last_endpoint(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
 }
 
 // LastEndpoint returns the current value of the socket's last_endpoint option

--- a/sock_option.gsl
+++ b/sock_option.gsl
@@ -41,11 +41,6 @@ import (
 .for option
 .if mode = "rw" | mode = "w"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
-// Set$(name:pascal) sets the $(name) option for the socket
-func (s *Sock) Set$(name:pascal)(val $(gotype)) {
-	C.zsock_set_$(name)(unsafe.Pointer(s.zsockT), C.int(val))
-}
-
 // SockSet$(name:pascal) sets the $(name) option for the socket
 func SockSet$(name:pascal)(v $(gotype)) SockOption {
 	return func(s *Sock) {
@@ -55,14 +50,6 @@ func SockSet$(name:pascal)(v $(gotype)) SockOption {
 
 .endif
 .if type = "string" | type = "key"
-// Set$(name:pascal) sets the $(name) option for the socket
-func (s *Sock) Set$(name:pascal)(val $(gotype)) {
-    cVal := C.CString(val)
-    defer C.free(unsafe.Pointer(cVal))
-
-	C.zsock_set_$(name)(unsafe.Pointer(s.zsockT), cVal)
-}
-
 // SockSet$(name:pascal) sets the $(name) option for the socket
 func SockSet$(name:pascal)(v $(gotype)) SockOption {
 	return func(s *Sock) {
@@ -77,12 +64,6 @@ func SockSet$(name:pascal)(v $(gotype)) SockOption {
 .if mode = "rw" | mode = "r"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
 // $(name:pascal) returns the current value of the socket's $(name) option
-func (s *Sock) $(name:pascal)() $(gotype) {
-	val := C.zsock_$(name)(unsafe.Pointer(s.zsockT))
-	return int(val)
-}
-
-// $(name:pascal) returns the current value of the socket's $(name) option
 func $(name:pascal)(s *Sock) $(gotype) {
 	val := C.zsock_$(name)(unsafe.Pointer(s.zsockT))
 	return int(val)
@@ -90,12 +71,6 @@ func $(name:pascal)(s *Sock) $(gotype) {
 
 .endif
 .if type = "string" | type = "key"
-// $(name:pascal) returns the current value of the socket's $(name) option
-func (s *Sock) $(name:pascal)() $(gotype) {
-	val := C.zsock_$(name)(unsafe.Pointer(s.zsockT))
-	return C.GoString(val)
-}
-
 // $(name:pascal) returns the current value of the socket's $(name) option
 func $(name:pascal)(s *Sock) $(gotype) {
 	val := C.zsock_$(name)(unsafe.Pointer(s.zsockT))

--- a/sock_option_test.go
+++ b/sock_option_test.go
@@ -20,17 +20,6 @@ package goczmq
 import (
 	"testing"
 )
-func TestDeprecatedHeartbeatIvl(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 2000
-	sock.SetHeartbeatIvl(testval)
-	val := sock.HeartbeatIvl()
-	if val != testval && val != 0 {
-		t.Errorf("HeartbeatIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestHeartbeatIvl(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := 2000
@@ -38,17 +27,6 @@ func TestHeartbeatIvl(t *testing.T) {
 	val := HeartbeatIvl(sock)
 	if val != testval && val != 0 {
 		t.Errorf("HeartbeatIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedHeartbeatTtl(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 4000
-	sock.SetHeartbeatTtl(testval)
-	val := sock.HeartbeatTtl()
-	if val != testval && val != 0 {
-		t.Errorf("HeartbeatTtl returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -64,17 +42,6 @@ func TestHeartbeatTtl(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedHeartbeatTimeout(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 6000
-	sock.SetHeartbeatTimeout(testval)
-	val := sock.HeartbeatTimeout()
-	if val != testval && val != 0 {
-		t.Errorf("HeartbeatTimeout returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestHeartbeatTimeout(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := 6000
@@ -82,17 +49,6 @@ func TestHeartbeatTimeout(t *testing.T) {
 	val := HeartbeatTimeout(sock)
 	if val != testval && val != 0 {
 		t.Errorf("HeartbeatTimeout returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedUseFd(t *testing.T) {
-	sock := NewSock(Req)
-	testval := 3
-	sock.SetUseFd(testval)
-	val := sock.UseFd()
-	if val != testval && val != 0 {
-		t.Errorf("UseFd returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -108,24 +64,10 @@ func TestUseFd(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedXPubManual(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := 1
-	sock.SetXPubManual(testval)
-	sock.Destroy()
-}
-
 func TestXPubManual(t *testing.T) {
 	sock := NewSock(XPub)
 	testval := 1
 	sock.SetOption(SockSetXPubManual(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedXPubWelcomeMsg(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := "welcome"
-	sock.SetXPubWelcomeMsg(testval)
 	sock.Destroy()
 }
 
@@ -136,28 +78,10 @@ func TestXPubWelcomeMsg(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedStreamNotify(t *testing.T) {
-	sock := NewSock(Stream)
-	testval := 1
-	sock.SetStreamNotify(testval)
-	sock.Destroy()
-}
-
 func TestStreamNotify(t *testing.T) {
 	sock := NewSock(Stream)
 	testval := 1
 	sock.SetOption(SockSetStreamNotify(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedInvertMatching(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := 1
-	sock.SetInvertMatching(testval)
-	val := sock.InvertMatching()
-	if val != testval && val != 0 {
-		t.Errorf("InvertMatching returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -172,28 +96,10 @@ func TestInvertMatching(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedXPubVerboser(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := 1
-	sock.SetXPubVerboser(testval)
-	sock.Destroy()
-}
-
 func TestXPubVerboser(t *testing.T) {
 	sock := NewSock(XPub)
 	testval := 1
 	sock.SetOption(SockSetXPubVerboser(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedConnectTimeout(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 200
-	sock.SetConnectTimeout(testval)
-	val := sock.ConnectTimeout()
-	if val != testval && val != 0 {
-		t.Errorf("ConnectTimeout returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -204,17 +110,6 @@ func TestConnectTimeout(t *testing.T) {
 	val := ConnectTimeout(sock)
 	if val != testval && val != 0 {
 		t.Errorf("ConnectTimeout returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedTcpMaxrt(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 200
-	sock.SetTcpMaxrt(testval)
-	val := sock.TcpMaxrt()
-	if val != testval && val != 0 {
-		t.Errorf("TcpMaxrt returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -230,17 +125,6 @@ func TestTcpMaxrt(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedMulticastMaxtpdu(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 1400
-	sock.SetMulticastMaxtpdu(testval)
-	val := sock.MulticastMaxtpdu()
-	if val != testval && val != 0 {
-		t.Errorf("MulticastMaxtpdu returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestMulticastMaxtpdu(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := 1400
@@ -252,28 +136,10 @@ func TestMulticastMaxtpdu(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedConnectRid(t *testing.T) {
-	sock := NewSock(Router)
-	testval := "ABCD"
-	sock.SetConnectRid(testval)
-	sock.Destroy()
-}
-
 func TestConnectRid(t *testing.T) {
 	sock := NewSock(Router)
 	testval := "ABCD"
 	sock.SetOption(SockSetConnectRid(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedHandshakeIvl(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 200
-	sock.SetHandshakeIvl(testval)
-	val := sock.HandshakeIvl()
-	if val != testval && val != 0 {
-		t.Errorf("HandshakeIvl returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -284,17 +150,6 @@ func TestHandshakeIvl(t *testing.T) {
 	val := HandshakeIvl(sock)
 	if val != testval && val != 0 {
 		t.Errorf("HandshakeIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedSocksProxy(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := "127.0.0.1"
-	sock.SetSocksProxy(testval)
-	val := sock.SocksProxy()
-	if val != testval && val != "" {
-		t.Errorf("SocksProxy returned %s should be %s", val, testval)
 	}
 	sock.Destroy()
 }
@@ -310,28 +165,10 @@ func TestSocksProxy(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedXPubNodrop(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := 1
-	sock.SetXPubNodrop(testval)
-	sock.Destroy()
-}
-
 func TestXPubNodrop(t *testing.T) {
 	sock := NewSock(XPub)
 	testval := 1
 	sock.SetOption(SockSetXPubNodrop(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedTos(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 1
-	sock.SetTos(testval)
-	val := sock.Tos()
-	if val != testval && val != 0 {
-		t.Errorf("Tos returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -346,24 +183,10 @@ func TestTos(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedRouterHandover(t *testing.T) {
-	sock := NewSock(Router)
-	testval := 1
-	sock.SetRouterHandover(testval)
-	sock.Destroy()
-}
-
 func TestRouterHandover(t *testing.T) {
 	sock := NewSock(Router)
 	testval := 1
 	sock.SetOption(SockSetRouterHandover(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedRouterMandatory(t *testing.T) {
-	sock := NewSock(Router)
-	testval := 1
-	sock.SetRouterMandatory(testval)
 	sock.Destroy()
 }
 
@@ -374,24 +197,10 @@ func TestRouterMandatory(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedProbeRouter(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 1
-	sock.SetProbeRouter(testval)
-	sock.Destroy()
-}
-
 func TestProbeRouter(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := 1
 	sock.SetOption(SockSetProbeRouter(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedReqRelaxed(t *testing.T) {
-	sock := NewSock(Req)
-	testval := 1
-	sock.SetReqRelaxed(testval)
 	sock.Destroy()
 }
 
@@ -402,24 +211,10 @@ func TestReqRelaxed(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedReqCorrelate(t *testing.T) {
-	sock := NewSock(Req)
-	testval := 1
-	sock.SetReqCorrelate(testval)
-	sock.Destroy()
-}
-
 func TestReqCorrelate(t *testing.T) {
 	sock := NewSock(Req)
 	testval := 1
 	sock.SetOption(SockSetReqCorrelate(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedConflate(t *testing.T) {
-	sock := NewSock(Push)
-	testval := 1
-	sock.SetConflate(testval)
 	sock.Destroy()
 }
 
@@ -430,17 +225,6 @@ func TestConflate(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedZapDomain(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "test"
-	sock.SetZapDomain(testval)
-	val := sock.ZapDomain()
-	if val != testval && val != "" {
-		t.Errorf("ZapDomain returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestZapDomain(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := "test"
@@ -448,17 +232,6 @@ func TestZapDomain(t *testing.T) {
 	val := ZapDomain(sock)
 	if val != testval && val != "" {
 		t.Errorf("ZapDomain returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedPlainServer(t *testing.T) {
-	sock := NewSock(Pub)
-	testval := 1
-	sock.SetPlainServer(testval)
-	val := sock.PlainServer()
-	if val != testval && val != 0 {
-		t.Errorf("PlainServer returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -474,17 +247,6 @@ func TestPlainServer(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedPlainUsername(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "test"
-	sock.SetPlainUsername(testval)
-	val := sock.PlainUsername()
-	if val != testval && val != "" {
-		t.Errorf("PlainUsername returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestPlainUsername(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := "test"
@@ -492,17 +254,6 @@ func TestPlainUsername(t *testing.T) {
 	val := PlainUsername(sock)
 	if val != testval && val != "" {
 		t.Errorf("PlainUsername returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedPlainPassword(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "test"
-	sock.SetPlainPassword(testval)
-	val := sock.PlainPassword()
-	if val != testval && val != "" {
-		t.Errorf("PlainPassword returned %s should be %s", val, testval)
 	}
 	sock.Destroy()
 }
@@ -518,17 +269,6 @@ func TestPlainPassword(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedIpv6(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetIpv6(testval)
-	val := sock.Ipv6()
-	if val != testval && val != 0 {
-		t.Errorf("Ipv6 returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestIpv6(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -536,17 +276,6 @@ func TestIpv6(t *testing.T) {
 	val := Ipv6(sock)
 	if val != testval && val != 0 {
 		t.Errorf("Ipv6 returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedImmediate(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := 1
-	sock.SetImmediate(testval)
-	val := sock.Immediate()
-	if val != testval && val != 0 {
-		t.Errorf("Immediate returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -562,28 +291,10 @@ func TestImmediate(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedRouterRaw(t *testing.T) {
-	sock := NewSock(Router)
-	testval := 1
-	sock.SetRouterRaw(testval)
-	sock.Destroy()
-}
-
 func TestRouterRaw(t *testing.T) {
 	sock := NewSock(Router)
 	testval := 1
 	sock.SetOption(SockSetRouterRaw(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedIpv4only(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetIpv4only(testval)
-	val := sock.Ipv4only()
-	if val != testval && val != 0 {
-		t.Errorf("Ipv4only returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -598,28 +309,10 @@ func TestIpv4only(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedDelayAttachOnConnect(t *testing.T) {
-	sock := NewSock(Pub)
-	testval := 1
-	sock.SetDelayAttachOnConnect(testval)
-	sock.Destroy()
-}
-
 func TestDelayAttachOnConnect(t *testing.T) {
 	sock := NewSock(Pub)
 	testval := 1
 	sock.SetOption(SockSetDelayAttachOnConnect(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedSndhwm(t *testing.T) {
-	sock := NewSock(Pub)
-	testval := 1
-	sock.SetSndhwm(testval)
-	val := sock.Sndhwm()
-	if val != testval && val != 0 {
-		t.Errorf("Sndhwm returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -630,17 +323,6 @@ func TestSndhwm(t *testing.T) {
 	val := Sndhwm(sock)
 	if val != testval && val != 0 {
 		t.Errorf("Sndhwm returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedRcvhwm(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetRcvhwm(testval)
-	val := sock.Rcvhwm()
-	if val != testval && val != 0 {
-		t.Errorf("Rcvhwm returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -656,17 +338,6 @@ func TestRcvhwm(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedAffinity(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetAffinity(testval)
-	val := sock.Affinity()
-	if val != testval && val != 0 {
-		t.Errorf("Affinity returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestAffinity(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -678,24 +349,10 @@ func TestAffinity(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedSubscribe(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "test"
-	sock.SetSubscribe(testval)
-	sock.Destroy()
-}
-
 func TestSubscribe(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := "test"
 	sock.SetOption(SockSetSubscribe(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedUnsubscribe(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "test"
-	sock.SetUnsubscribe(testval)
 	sock.Destroy()
 }
 
@@ -706,17 +363,6 @@ func TestUnsubscribe(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedIdentity(t *testing.T) {
-	sock := NewSock(Dealer)
-	testval := "test"
-	sock.SetIdentity(testval)
-	val := sock.Identity()
-	if val != testval && val != "" {
-		t.Errorf("Identity returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestIdentity(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := "test"
@@ -724,17 +370,6 @@ func TestIdentity(t *testing.T) {
 	val := Identity(sock)
 	if val != testval && val != "" {
 		t.Errorf("Identity returned %s should be %s", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedRate(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetRate(testval)
-	val := sock.Rate()
-	if val != testval && val != 0 {
-		t.Errorf("Rate returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -750,17 +385,6 @@ func TestRate(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedRecoveryIvl(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetRecoveryIvl(testval)
-	val := sock.RecoveryIvl()
-	if val != testval && val != 0 {
-		t.Errorf("RecoveryIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestRecoveryIvl(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -768,17 +392,6 @@ func TestRecoveryIvl(t *testing.T) {
 	val := RecoveryIvl(sock)
 	if val != testval && val != 0 {
 		t.Errorf("RecoveryIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedSndbuf(t *testing.T) {
-	sock := NewSock(Pub)
-	testval := 1
-	sock.SetSndbuf(testval)
-	val := sock.Sndbuf()
-	if val != testval && val != 0 {
-		t.Errorf("Sndbuf returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -794,17 +407,6 @@ func TestSndbuf(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedRcvbuf(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetRcvbuf(testval)
-	val := sock.Rcvbuf()
-	if val != testval && val != 0 {
-		t.Errorf("Rcvbuf returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestRcvbuf(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -812,17 +414,6 @@ func TestRcvbuf(t *testing.T) {
 	val := Rcvbuf(sock)
 	if val != testval && val != 0 {
 		t.Errorf("Rcvbuf returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedLinger(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetLinger(testval)
-	val := sock.Linger()
-	if val != testval && val != 0 {
-		t.Errorf("Linger returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -838,17 +429,6 @@ func TestLinger(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedReconnectIvl(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetReconnectIvl(testval)
-	val := sock.ReconnectIvl()
-	if val != testval && val != 0 {
-		t.Errorf("ReconnectIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestReconnectIvl(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -856,17 +436,6 @@ func TestReconnectIvl(t *testing.T) {
 	val := ReconnectIvl(sock)
 	if val != testval && val != 0 {
 		t.Errorf("ReconnectIvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedReconnectIvlMax(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetReconnectIvlMax(testval)
-	val := sock.ReconnectIvlMax()
-	if val != testval && val != 0 {
-		t.Errorf("ReconnectIvlMax returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -882,17 +451,6 @@ func TestReconnectIvlMax(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedBacklog(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetBacklog(testval)
-	val := sock.Backlog()
-	if val != testval && val != 0 {
-		t.Errorf("Backlog returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestBacklog(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -900,17 +458,6 @@ func TestBacklog(t *testing.T) {
 	val := Backlog(sock)
 	if val != testval && val != 0 {
 		t.Errorf("Backlog returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedMaxmsgsize(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetMaxmsgsize(testval)
-	val := sock.Maxmsgsize()
-	if val != testval && val != 0 {
-		t.Errorf("Maxmsgsize returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -926,17 +473,6 @@ func TestMaxmsgsize(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedMulticastHops(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetMulticastHops(testval)
-	val := sock.MulticastHops()
-	if val != testval && val != 0 {
-		t.Errorf("MulticastHops returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestMulticastHops(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -944,17 +480,6 @@ func TestMulticastHops(t *testing.T) {
 	val := MulticastHops(sock)
 	if val != testval && val != 0 {
 		t.Errorf("MulticastHops returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedRcvtimeo(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetRcvtimeo(testval)
-	val := sock.Rcvtimeo()
-	if val != testval && val != 0 {
-		t.Errorf("Rcvtimeo returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -970,17 +495,6 @@ func TestRcvtimeo(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedSndtimeo(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetSndtimeo(testval)
-	val := sock.Sndtimeo()
-	if val != testval && val != 0 {
-		t.Errorf("Sndtimeo returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestSndtimeo(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -992,28 +506,10 @@ func TestSndtimeo(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedXPubVerbose(t *testing.T) {
-	sock := NewSock(XPub)
-	testval := 1
-	sock.SetXPubVerbose(testval)
-	sock.Destroy()
-}
-
 func TestXPubVerbose(t *testing.T) {
 	sock := NewSock(XPub)
 	testval := 1
 	sock.SetOption(SockSetXPubVerbose(testval))
-	sock.Destroy()
-}
-
-func TestDeprecatedTcpKeepalive(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetTcpKeepalive(testval)
-	val := sock.TcpKeepalive()
-	if val != testval && val != 0 {
-		t.Errorf("TcpKeepalive returned %d, should be %d", val, testval)
-	}
 	sock.Destroy()
 }
 
@@ -1024,17 +520,6 @@ func TestTcpKeepalive(t *testing.T) {
 	val := TcpKeepalive(sock)
 	if val != testval && val != 0 {
 		t.Errorf("TcpKeepalive returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedTcpKeepaliveIdle(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetTcpKeepaliveIdle(testval)
-	val := sock.TcpKeepaliveIdle()
-	if val != testval && val != 0 {
-		t.Errorf("TcpKeepaliveIdle returned %d, should be %d", val, testval)
 	}
 	sock.Destroy()
 }
@@ -1050,17 +535,6 @@ func TestTcpKeepaliveIdle(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedTcpKeepaliveCnt(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetTcpKeepaliveCnt(testval)
-	val := sock.TcpKeepaliveCnt()
-	if val != testval && val != 0 {
-		t.Errorf("TcpKeepaliveCnt returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestTcpKeepaliveCnt(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -1072,17 +546,6 @@ func TestTcpKeepaliveCnt(t *testing.T) {
 	sock.Destroy()
 }
 
-func TestDeprecatedTcpKeepaliveIntvl(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := 1
-	sock.SetTcpKeepaliveIntvl(testval)
-	val := sock.TcpKeepaliveIntvl()
-	if val != testval && val != 0 {
-		t.Errorf("TcpKeepaliveIntvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
 func TestTcpKeepaliveIntvl(t *testing.T) {
 	sock := NewSock(Sub)
 	testval := 1
@@ -1090,17 +553,6 @@ func TestTcpKeepaliveIntvl(t *testing.T) {
 	val := TcpKeepaliveIntvl(sock)
 	if val != testval && val != 0 {
 		t.Errorf("TcpKeepaliveIntvl returned %d, should be %d", val, testval)
-	}
-	sock.Destroy()
-}
-
-func TestDeprecatedTcpAcceptFilter(t *testing.T) {
-	sock := NewSock(Sub)
-	testval := "127.0.0.1"
-	sock.SetTcpAcceptFilter(testval)
-	val := sock.TcpAcceptFilter()
-	if val != testval && val != "" {
-		t.Errorf("TcpAcceptFilter returned %s should be %s", val, testval)
 	}
 	sock.Destroy()
 }

--- a/sock_option_test.gsl
+++ b/sock_option_test.gsl
@@ -30,19 +30,6 @@ import (
 .for option where defined(test)
 .if mode = "rw" | mode = "w"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
-func TestDeprecated$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:neat))
-	testval := $(test_value?'1':)
-	sock.Set$(name:pascal)(testval)
-.if mode = "rw"
-	val := sock.$(name:pascal)()
-	if val != testval && val != 0 {
-		t.Errorf("$(name:pascal) returned %d, should be %d", val, testval)
-	}
-.endif
-	sock.Destroy()
-}
-
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewSock($(test:neat))
 	testval := $(test_value?'1':)
@@ -58,19 +45,6 @@ func Test$(name:pascal)(t *testing.T) {
 
 .endif
 .if type = "string" | type = "key"
-func TestDeprecated$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:neat))
-	testval := "$(test_value?'test':)"
-	sock.Set$(name:pascal)(testval)
-.if mode = "rw"
-	val := sock.$(name:pascal)()
-	if val != testval && val != "" {
-		t.Errorf("$(name:pascal) returned %s should be %s", val, testval)
-	}
-.endif
-	sock.Destroy()
-}
-
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewSock($(test:neat))
 	testval := "$(test_value?'test':)"
@@ -87,12 +61,6 @@ func Test$(name:pascal)(t *testing.T) {
 .endif
 .if mode = "r"
 .if type = "uint64" | type = "int64" | type = "uint32" | type = "int"
-func TestDeprecated$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:neat))
-	_ = sock.$(name:pascal)()
-	sock.Destroy()
-}
-
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewSock($(test:neat))
 	_ = $(name:pascal)(sock)
@@ -101,12 +69,6 @@ func Test$(name:pascal)(t *testing.T) {
 
 .endif
 .if type = "string" | type = "key"
-func TestDeprecated$(name:pascal)(t *testing.T) {
-	sock := NewSock($(test:pascal))
-	_ = sock.$(name:pascal)()
-	sock.Destroy()
-}
-
 func Test$(name:pascal)(t *testing.T) {
 	sock := NewSock($(test:pascal))
 	_ = sock.$(name:pascal)()


### PR DESCRIPTION
The old socket option interface was inflexible due to having to add new functions directly to *Sock to expand it, cluttering the Sock API with a lot of optional and often not used functions. Awhile back, I created a new function args API and marked the old API deprecated. In preparation for a new release of GoCZMQ I'm not removing the deprecated API.