### PR TITLE
CURVE support for Proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/zeromq/goczmq/v4
 
 go 1.12
+
+require github.com/tilinna/z85 v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/tilinna/z85 v1.0.0 h1:uqFnJBlD01dosSeo5sK1G1YGbPuwqVHqR+12OJDRjUw=
+github.com/tilinna/z85 v1.0.0/go.mod h1:EfpFU/DUY4ddEy6CRvk2l+UQNEzHbh+bqBQS+04Nkxs=

--- a/proxy.go
+++ b/proxy.go
@@ -66,6 +66,84 @@ func (p *Proxy) SetFrontend(sockType int, endpoint string) error {
 	return nil
 }
 
+// SetFrontendDomain accepts a domain, and sends a message
+// to the zactor thread telling it to set up ZAP authentication domain for the socket.
+func (p *Proxy) SetFrontendDomain(domain string) error {
+	cmd := C.CString("DOMAIN")
+	defer C.free(unsafe.Pointer(cmd))
+
+	sock := C.CString("FRONTEND")
+	defer C.free(unsafe.Pointer(sock))
+
+	cDomainString := C.CString(domain)
+	defer C.free(unsafe.Pointer(cDomainString))
+
+	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), cmd)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), sock)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_send(unsafe.Pointer(p.zactorT), cDomainString)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zsock_wait(unsafe.Pointer(p.zactorT))
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
+// SetFrontendCurve accepts Z85 encoded public and secret keys and sends a message
+// to the zactor thread telling it to set up CURVE authentication for the socket.
+func (p *Proxy) SetFrontendCurve(publicKey string, secretKey string) error {
+	cmd := C.CString("CURVE")
+	defer C.free(unsafe.Pointer(cmd))
+
+	sock := C.CString("FRONTEND")
+	defer C.free(unsafe.Pointer(sock))
+
+	cPublicKey := C.CString(publicKey)
+	defer C.free(unsafe.Pointer(cPublicKey))
+
+	cSecretKey := C.CString(secretKey)
+	defer C.free(unsafe.Pointer(cSecretKey))
+
+	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), cmd)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), sock)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), cPublicKey)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_send(unsafe.Pointer(p.zactorT), cSecretKey)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zsock_wait(unsafe.Pointer(p.zactorT))
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
 // SetBackend accepts a socket type and endpoint, and sends a message
 // to the zactor thread telling it to set up a socket bound to the endpoint.
 func (p *Proxy) SetBackend(sockType int, endpoint string) error {
@@ -91,6 +169,84 @@ func (p *Proxy) SetBackend(sockType int, endpoint string) error {
 	}
 
 	rc = C.zstr_send(unsafe.Pointer(p.zactorT), cEndpoint)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zsock_wait(unsafe.Pointer(p.zactorT))
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
+// SetBackendDomain accepts a domain, and sends a message
+// to the zactor thread telling it to set up ZAP authentication domain for the socket.
+func (p *Proxy) SetBackendDomain(domain string) error {
+	cmd := C.CString("DOMAIN")
+	defer C.free(unsafe.Pointer(cmd))
+
+	sock := C.CString("BACKEND")
+	defer C.free(unsafe.Pointer(sock))
+
+	cDomainString := C.CString(domain)
+	defer C.free(unsafe.Pointer(cDomainString))
+
+	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), cmd)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), sock)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_send(unsafe.Pointer(p.zactorT), cDomainString)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zsock_wait(unsafe.Pointer(p.zactorT))
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
+// SetBackendCurve accepts Z85 encoded public and secret keys and sends a message
+// to the zactor thread telling it to set up CURVE authentication for the socket.
+func (p *Proxy) SetBackendCurve(publicKey string, secretKey string) error {
+	cmd := C.CString("CURVE")
+	defer C.free(unsafe.Pointer(cmd))
+
+	sock := C.CString("BACKEND")
+	defer C.free(unsafe.Pointer(sock))
+
+	cPublicKey := C.CString(publicKey)
+	defer C.free(unsafe.Pointer(cPublicKey))
+
+	cSecretKey := C.CString(secretKey)
+	defer C.free(unsafe.Pointer(cSecretKey))
+
+	rc := C.zstr_sendm(unsafe.Pointer(p.zactorT), cmd)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), sock)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_sendm(unsafe.Pointer(p.zactorT), cPublicKey)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	rc = C.zstr_send(unsafe.Pointer(p.zactorT), cSecretKey)
 	if rc == -1 {
 		return ErrActorCmd
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -239,8 +239,8 @@ func TestProxyCurve(t *testing.T) {
 	defer faucet.Destroy()
 
 	sink := NewSock(Pull)
-	faucet.SetOption(SockSetCurveServer(1))
-	serverCert.Apply(faucet)
+	sink.SetOption(SockSetCurveServerkey(serverCert.PublicText()))
+	clientCert.Apply(sink)
 	err = sink.Connect("inproc://backend")
 	if err != nil {
 		t.Error(err)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -3,6 +3,7 @@ package goczmq
 import (
 	"fmt"
 	"testing"
+	"github.com/tilinna/z85"
 )
 
 func TestProxy(t *testing.T) {
@@ -170,6 +171,100 @@ func TestProxy(t *testing.T) {
 	}
 
 	proxy.Destroy()
+}
+
+func TestProxyCurve(t *testing.T) {
+	serverPubKey := "j+KTl+V-G75#pBWwItQta7<5Rzs:N$1xFwjW2{C2"
+	serverSecretKey := "*i(F-QJdIE04$AtHVoo.AwGjcM}0sN../[j)<)N}"
+	serverPubKeyBinary := make([]byte, z85.DecodedLen(len(serverPubKey)))
+	serverSecretKeyBinary := make([]byte, z85.DecodedLen(len(serverSecretKey)))
+	if _, err := z85.Decode(serverPubKeyBinary, []byte(serverPubKey)); err != nil {
+		t.Error(err)
+	}
+	if _, err := z85.Decode(serverSecretKeyBinary, []byte(serverSecretKey)); err != nil {
+		t.Error(err)
+	}
+
+	serverCert, err := NewCertFromKeys(serverPubKeyBinary, serverSecretKeyBinary)
+	if err != nil {
+		t.Error(err)
+	}
+	clientCert := NewCert()
+
+	// Create and configure our proxy
+	proxy := NewProxy()
+	defer proxy.Destroy()
+
+	if testing.Verbose() {
+		err = proxy.Verbose()
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	err = proxy.SetFrontendDomain("global")
+	if err != nil {
+		t.Error(err)
+	}
+	err = proxy.SetFrontendCurve(serverPubKey, serverSecretKey)
+	if err != nil {
+		t.Error(err)
+	}
+	err = proxy.SetFrontend(Pull, "inproc://frontend")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = proxy.SetBackendDomain("global")
+	if err != nil {
+		t.Error(err)
+	}
+	err = proxy.SetBackendCurve(serverPubKey, serverSecretKey)
+	if err != nil {
+		t.Error(err)
+	}
+	err = proxy.SetBackend(Push, "inproc://backend")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// connect application sockets to proxy
+	faucet := NewSock(Push)
+	faucet.SetOption(SockSetCurveServerkey(serverCert.PublicText()))
+	clientCert.Apply(faucet)
+	err = faucet.Connect("inproc://frontend")
+	if err != nil {
+		t.Error(err)
+	}
+	defer faucet.Destroy()
+
+	sink := NewSock(Pull)
+	faucet.SetOption(SockSetCurveServer(1))
+	serverCert.Apply(faucet)
+	err = sink.Connect("inproc://backend")
+	if err != nil {
+		t.Error(err)
+	}
+	defer sink.Destroy()
+
+	// send some messages and check they arrived
+	err = faucet.SendFrame([]byte("Hello"), FlagNone)
+	if err != nil {
+		t.Error(err)
+	}
+
+	b, f, err := sink.RecvFrame()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, have := false, f == FlagMore; want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	if want, have := "Hello", string(b); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
 }
 
 func ExampleProxy() {


### PR DESCRIPTION
CURVE support for the underlying zproxy.
This mirrors the API in the underlying czmq library. I'm happy to switch things around wrt naming/semantics and add more tests if required.