### PR TITLE
Monitor actor for obtaining socket events

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,91 @@
+package goczmq
+
+/*
+#include "czmq.h"
+
+zactor_t *Monitor_new (zsock_t *sock) {
+	zactor_t *monitor = zactor_new(zmonitor, sock);
+	return monitor;
+}
+
+int Monitor_verbose (zactor_t *monitor) {
+	return zstr_sendx(monitor, "VERBOSE", NULL);
+}
+
+int Monitor_listen (zactor_t *monitor, const char *type) {
+	return zstr_sendx(monitor, "LISTEN", type, NULL);
+}
+
+void Monitor_destroy (zactor_t *monitor) {
+	zactor_destroy(&monitor);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Monitor provides an API for obtaining socket events
+type Monitor struct {
+	zactorT *C.struct__zactor_t
+}
+
+// NewMonitor creates new Monitor actor.
+func NewMonitor(socket *Sock) *Monitor {
+	m := &Monitor{}
+	m.zactorT = C.Monitor_new((*C.struct__zsock_t)(unsafe.Pointer(socket.zsockT)))
+	return m
+}
+
+// Listen specifies which events to listen for. "ALL" is also supported.
+func (m *Monitor) Listen(event string) error {
+	cmd := C.CString("LISTEN")
+	defer C.free(unsafe.Pointer(cmd))
+
+	eventStr := C.CString(event)
+	defer C.free(unsafe.Pointer(eventStr))
+
+	rc := C.Monitor_listen((*C.struct__zactor_t)(unsafe.Pointer(m.zactorT)), eventStr)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
+// Start activates the socket monitoring. Additional Listen() calls will not have an effect after this.
+func (m *Monitor) Start() error {
+	cmd := C.CString("START")
+	defer C.free(unsafe.Pointer(cmd))
+
+	rc := C.zstr_send(unsafe.Pointer(m.zactorT), cmd)
+	if rc == -1 {
+		return ErrActorCmd
+	}
+	C.zsock_wait(unsafe.Pointer(m.zactorT))
+
+	return nil
+}
+
+// Verbose enables verbose mode, logging activity to stdout
+func (m *Monitor) Verbose() error {
+	rc := C.Monitor_verbose((*C.struct__zactor_t)(unsafe.Pointer(m.zactorT)))
+	if rc == -1 {
+		return ErrActorCmd
+	}
+
+	return nil
+}
+
+// Socket returns the actor as a Sock instance, useful and necessary for being able to receive messages
+func (m *Monitor) Socket() *Sock {
+	s := &Sock{}
+	s.zsockT = (*C.struct__zsock_t)(unsafe.Pointer(m.zactorT))
+	return s
+}
+
+// Destroy destroys the monitor instance
+func (m *Monitor) Destroy() {
+	C.Monitor_destroy((*C.struct__zactor_t)(unsafe.Pointer(m.zactorT)))
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,0 +1,63 @@
+package goczmq
+
+import (
+	"fmt"
+	"testing"
+)
+
+func assertEvent(t *testing.T, monitor *Monitor, expectedEvent string) {
+	poller, _ := NewPoller(monitor.Socket())
+	defer poller.Destroy()
+
+	socket, _ := poller.Wait(100)
+
+	if socket == nil {
+		t.Error("No messages received on monitor socket for 1 second")
+		return
+	}
+
+	msg, _ := socket.RecvMessage()
+
+	if len(msg) != 3 {
+		t.Errorf("Expected message with 3 frames, got %v", len(msg))
+	}
+
+	eventName := string(msg[0])
+
+	if eventName != expectedEvent {
+		t.Errorf("Expected %v event, got %v", expectedEvent, eventName)
+		return
+	}
+}
+
+func TestMonitor(t *testing.T) {
+	client := NewSock(Dealer)
+	defer client.Destroy()
+
+	clientmon := NewMonitor(client)
+	defer clientmon.Destroy()
+
+	clientmon.Verbose()
+
+	clientmon.Listen("LISTENING")
+	clientmon.Listen("ACCEPTED")
+	clientmon.Start()
+
+	server := NewSock(Dealer)
+	defer server.Destroy()
+
+	servermon := NewMonitor(server)
+	defer servermon.Destroy()
+
+	servermon.Listen("CONNECTED")
+	servermon.Listen("DISCONNECTED")
+	servermon.Start()
+
+	port, _ := client.Bind("tcp://127.0.0.1:*")
+	assertEvent(t, clientmon, "LISTENING")
+
+	server.Connect(fmt.Sprint("tcp://127.0.0.1:", port))
+	assertEvent(t, servermon, "CONNECTED")
+
+	assertEvent(t, clientmon, "ACCEPTED")
+}


### PR DESCRIPTION
This is a wrapper for the czmq zmonitor actor. It allows listening for some events that otherwise might be impossible to receive. Includes minimal API needed to create and destroy the actor.