### PR TITLE
Fix issue with creater a poller with nil readers

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -27,7 +27,7 @@ type Poller struct {
 // It accepts one or more readers to poll.
 func NewPoller(readers ...*Sock) (*Poller, error) {
 	var p *Poller
-	if len(readers) == 0 {
+	if len(readers) == 0 || readers == nil {
 		p = &Poller{
 			zpollerT: C.Poller_new(nil),
 			socks:    make([]*Sock, 0),


### PR DESCRIPTION
The following

```poller, err := zmq.NewPoller(nil)```

generates

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x52ff5f]
```

at line 37 in `poller.go`.

This PR simply checks for nil as an argument for `NewPoller`. 