### PR TITLE
Problem: socket interactions randomly fail due to EINTR

### DIFF
--- a/goczmq.go
+++ b/goczmq.go
@@ -26,6 +26,7 @@ import "C"
 
 import (
 	"errors"
+	"syscall"
 )
 
 const (
@@ -201,4 +202,12 @@ func getStringType(k int) string {
 	default:
 		return ""
 	}
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	eno, ok := err.(syscall.Errno)
+	return ok && eno == syscall.EINTR
 }


### PR DESCRIPTION
Solution: retry functions that are likely to fail with EINTR


This relates to [changes made in Go 1.14](https://golang.org/doc/go1.14#runtime) but also applies to 1.15.

Example applications that fail only without the patch (note that although these will definitely fail on both 1.14 and 1.15 it happens very quickly with 1.14 while it can take several minutes on 1.15)

pub.go:
```go
package main

import (
	"time"

	"github.com/zeromq/goczmq/v4"
)

func main() {
	c := goczmq.NewPubChanneler("@tcp://*:20001")
	defer c.Destroy()

	t := time.NewTicker(1 * time.Nanosecond)

	for {
		select {
		case err := <-c.ErrChan:
			panic(err)
		case <-t.C:
			c.SendChan <- [][]byte{[]byte("X"), []byte("OK")}
		}
	}
}
```

sub.go
```go
package main

import (
	"github.com/zeromq/goczmq/v4"
)

func main() {
	c := goczmq.NewSubChanneler("tcp://localhost:20001")
	defer c.Destroy()
	c.Subscribe("X")

	for {
		select {
		case err := <-c.ErrChan:
			panic(err)
		case <-c.RecvChan:
		}
	}
}
```

Output without the patch for pub.go:
```
panic: recv frame error
```

for sub.go (this will only fail if the pub.go process is also runnning. To reproduce quicker it helps to run many instances in parallel):
```
panic: recv frame error
```

From what I could tell from using `strace` it appears the `EINTR` for ZMQ send and receive calls is commonly caused by `epoll_pwait` which indeed is listed in [man 7 signal](https://linux.die.net/man/7/signal) as not being automatically restarted even with `SA_RESTART` being used by all signal handlers.

A similar but more comprehensive and flexible solution has also been implemented in [zmq4](https://github.com/pebbe/zmq4/blob/master/errors.go#L94). In this patch I've covered the most common and likely codepaths to hit this issue with goczmq.

Almost certainly this patch fixes https://github.com/zeromq/goczmq/issues/278, I adapted the test script there to goczmq master and the recv frame errors stopped happening with the patch applied.