### PR TITLE
Problem: Pollin()/Pollout() misbehave with Router socket

### DIFF
--- a/sock.go
+++ b/sock.go
@@ -271,13 +271,13 @@ func NewStream(endpoints string, options ...SockOption) (*Sock, error) {
 // Pollin returns true if there is a Pollin
 // event on the socket
 func (s *Sock) Pollin() bool {
-	return Events(s) == Pollin
+	return Events(s)&Pollin == Pollin
 }
 
 // Pollout returns true if there is a Pollout
 // event on the socket
 func (s *Sock) Pollout() bool {
-	return Events(s) == Pollout
+	return Events(s)&Pollout == Pollout
 }
 
 // SendFrame sends a byte array via the socket.  For the flags

--- a/sock_test.go
+++ b/sock_test.go
@@ -451,6 +451,42 @@ func TestPollin(t *testing.T) {
 	}
 }
 
+func TestPollinPolloutRouter(t *testing.T) {
+	router, err := NewRouter("inproc://router")
+	if err != nil {
+		t.Error(err)
+	}
+	defer router.Destroy()
+
+	dealer, err := NewDealer("inproc://router")
+	if err != nil {
+		t.Error(err)
+	}
+	defer dealer.Destroy()
+
+	// for Router pollout is always true
+	if want, have := true, router.Pollout(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	if want, have := false, router.Pollin(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	err = dealer.SendFrame([]byte("Hello World"), FlagNone)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, have := true, router.Pollin(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+
+	if want, have := true, router.Pollout(); want != have {
+		t.Errorf("want %#v, have %#v", want, have)
+	}
+}
+
 func TestPollout(t *testing.T) {
 	push := NewSock(Push)
 	_, err := push.Bind("inproc://pollout")


### PR DESCRIPTION
Solution: fix bitmask match against ZMQ_EVENTS

This fixes https://github.com/zeromq/goczmq/issues/266

Basically current `Pollin`/`Pollout` implementation returns false negatives if multiple events are present at the same time, this is a common situation with Router socket.