### PR TITLE
Problem: ZMQ_ROUTER_NOTIFY not supported

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -210,7 +210,7 @@ func TestProxyCurve(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = proxy.SetFrontend(Pull, "inproc://frontend")
+	err = proxy.SetFrontend(Pull, "inproc://curveFrontend")
 	if err != nil {
 		t.Error(err)
 	}
@@ -223,7 +223,7 @@ func TestProxyCurve(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = proxy.SetBackend(Push, "inproc://backend")
+	err = proxy.SetBackend(Push, "inproc://curveBackend")
 	if err != nil {
 		t.Error(err)
 	}
@@ -232,7 +232,7 @@ func TestProxyCurve(t *testing.T) {
 	faucet := NewSock(Push)
 	faucet.SetOption(SockSetCurveServerkey(serverCert.PublicText()))
 	clientCert.Apply(faucet)
-	err = faucet.Connect("inproc://frontend")
+	err = faucet.Connect("inproc://curveFrontend")
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,7 +241,7 @@ func TestProxyCurve(t *testing.T) {
 	sink := NewSock(Pull)
 	sink.SetOption(SockSetCurveServerkey(serverCert.PublicText()))
 	clientCert.Apply(sink)
-	err = sink.Connect("inproc://backend")
+	err = sink.Connect("inproc://curveBackend")
 	if err != nil {
 		t.Error(err)
 	}

--- a/sock_option.go
+++ b/sock_option.go
@@ -31,6 +31,13 @@ import (
 	"unsafe"
 )
 
+// SockSetRouterNotify sets the router_notify option for the socket
+func SockSetRouterNotify(v int) SockOption {
+	return func(s *Sock) {
+		C.zsock_set_router_notify(unsafe.Pointer(s.zsockT), C.int(v))
+	}
+}
+
 // SockSetHeartbeatIvl sets the heartbeat_ivl option for the socket
 func SockSetHeartbeatIvl(v int) SockOption {
 	return func(s *Sock) {

--- a/sock_option_test.go
+++ b/sock_option_test.go
@@ -20,6 +20,13 @@ package goczmq
 import (
 	"testing"
 )
+func TestRouterNotify(t *testing.T) {
+	sock := NewSock(Router)
+	testval := 1
+	sock.SetOption(SockSetRouterNotify(testval))
+	sock.Destroy()
+}
+
 func TestHeartbeatIvl(t *testing.T) {
 	sock := NewSock(Dealer)
 	testval := 2000

--- a/sockopts.xml
+++ b/sockopts.xml
@@ -5,6 +5,14 @@
 -->
 
 <options script = "sockopts">
+    <version major = "4" minor = "3" style = "macro">
+        <!-- Options that are new in 4.3 -->
+        <option name = "router_notify"     type = "int"    mode = "w"  test = "ROUTER"
+            test_value = "1" >
+            <restrict type = "ROUTER" />
+        </option>
+    </version>
+
     <version major = "4" minor = "2" style = "macro">
         <!-- Options that are new in 4.2 -->
         <option name = "heartbeat_ivl"     type = "int"    mode = "rw" test = "DEALER"


### PR DESCRIPTION
This exposes the ZMQ_ROUTER_NOTIFY option for goczmq users.

It's a draft option but hopefully it's ok to follow the czmq convention of having draft options setters be no-ops when the libzmq build hasn't enabled drafts (as is the case for `zsock_set_router_notify` [here](https://github.com/zeromq/czmq/blob/06441e529c758e1ce410f22d10d95e42cc991cb5/src/zsock_option.inc#L425))