### PR TITLE
Add in-memory CertStore support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before you send a pull request, please familiarize yourself with the [C4.1 Colle
 
 "A Problem" should be one single clear problem. Large complex problems should be broken down into a series of smaller problems when ever possible.
 
-**Please be aware** that GoCZMQ is **not versioned**. We merge to master. We deploy from master. Master is epxected to be working, at all times. We strive to do our very best to never break public API in this library. Changes can be additive, but they can not break the existing API. If a case arises where we need to, we will be loud about it on the ZeroMQ mailing list and try to build consensus among current maintainers that it's necessary. We will be very chagrined about it, and you can poke fun at us a bit.
+**Please be aware** that GoCZMQ is **not versioned**. We merge to master. We deploy from master. Master is expected to be working, at all times. We strive to do our very best to never break public API in this library. Changes can be additive, but they can not break the existing API. If a case arises where we need to, we will be loud about it on the ZeroMQ mailing list and try to build consensus among current maintainers that it's necessary. We will be very chagrined about it, and you can poke fun at us a bit.
 
 # Style Guide
 * Your code must be formatted with [Gofmt](https://blog.golang.org/go-fmt-your-code)

--- a/certstore.go
+++ b/certstore.go
@@ -27,6 +27,13 @@ func NewCertStore(location string) *CertStore {
 	}
 }
 
+// NewCertStoreInMemory creates a new certificate store in memory.
+func NewCertStoreInMemory() *CertStore {
+	return &CertStore{
+		zcertstoreT: C.zcertstore_new(nil),
+        }
+}
+
 // Insert inserts a certificate into the store in memory.
 // Call Save directly on the cert if you wish to save it
 // to disk.

--- a/certstore_test.go
+++ b/certstore_test.go
@@ -65,3 +65,18 @@ func TestCertStore(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestCertStoreMem(t *testing.T) {
+	certstore := NewCertStoreInMemory()
+	defer certstore.Destroy()
+
+	client0 := NewCert()
+	client0Key := client0.PublicText()
+	client0.Destroy()
+	client0Loaded := certstore.Lookup(client0Key)
+
+	if client0Loaded != nil {
+		t.Errorf("want %#v, have %#v", nil, client0Loaded)
+
+	}
+}


### PR DESCRIPTION
While trying to use CertStore, I found that using czmq's in-memory zcertstore wasn't possible through goczmq. Here's a small patch to add that functionality along with a subset of the main certstore tests.